### PR TITLE
Do signal xapi when an IP address is removed

### DIFF
--- a/networkd/network_monitor_thread.ml
+++ b/networkd/network_monitor_thread.ml
@@ -263,8 +263,7 @@ let ip_watcher () =
 	let rec loop () =
 		let line = input_line in_channel in
 		(* Do not send events for link-local IPv6 addresses, and removed IPs *)
-		if String.has_substr line "inet" && not (String.has_substr line "inet6 fe80") &&
-			not (String.has_substr line "Deleted") then begin
+		if String.has_substr line "inet" && not (String.has_substr line "inet6 fe80") then begin
 			(* Ignore changes for the next second, since they usually come in bursts,
 			 * and signal only once. *)
 			Thread.delay 1.;


### PR DESCRIPTION
BobB pointed out that when a DHCP lease expires, the IP address may go away.
Therefore, a signal to xapi for it to update its DB makes sense.

Signed-off-by: Rob Hoes rob.hoes@citrix.com
