### PR TITLE
Get network stats through netlink rather than from /proc

### DIFF
--- a/xcp-networkd.obuild
+++ b/xcp-networkd.obuild
@@ -13,7 +13,7 @@ library network-libs
 executable xcp-networkd
   main: networkd.ml
   src-dir: networkd
-  build-deps: threads, rpclib, rpclib.unix, forkexec, stdext, log, http-svr, xcp-inventory, network-libs, xen-api-client, xcp, xcp.network
+  build-deps: threads, rpclib, rpclib.unix, forkexec, stdext, log, http-svr, xcp-inventory, network-libs, xen-api-client, xcp, xcp.network, netlink
   pp: camlp4o
 
 executable networkd_db


### PR DESCRIPTION
This add a dependency to the netlink opam package, and the libnl-3
and libnl-route-3 libraries.

NOTE: only merge once we are happy with these dependencies!
