### PR TITLE
CA-116420: when creating linux bond, add MAC address after adding bond slaves

### DIFF
--- a/networkd/network_server.ml
+++ b/networkd/network_server.ml
@@ -632,12 +632,12 @@ module Bridge = struct
 				end else begin
 					if not (List.mem name (Sysfs.bridge_to_interfaces bridge)) then begin
 						Linux_bonding.add_bond_master name;
+						List.iter (fun name -> Interface.bring_down () dbg ~name) interfaces;
+						List.iter (Linux_bonding.add_bond_slave name) interfaces;
 						begin match bond_mac with
 							| Some mac -> Ip.set_mac name mac
 							| None -> warn "No MAC address specified for the bond"
 						end;
-						List.iter (fun name -> Interface.bring_down () dbg ~name) interfaces;
-						List.iter (Linux_bonding.add_bond_slave name) interfaces;
 						let bond_properties =
 							if List.mem_assoc "mode" bond_properties && List.assoc "mode" bond_properties = "lacp" then
 								List.replace_assoc "mode" "802.3ad" bond_properties


### PR DESCRIPTION
This is needed under kernel 3.x, because the kernel now changes the bond MAC to
the MAC of the first slave that is added, which is not always what we want.

Signed-off-by: Rob Hoes rob.hoes@citrix.com
