### PR TITLE
Remove http-svr dependency

### DIFF
--- a/xcp-networkd.obuild
+++ b/xcp-networkd.obuild
@@ -13,7 +13,7 @@ library network-libs
 executable xcp-networkd
   main: networkd.ml
   src-dir: networkd
-  build-deps: threads, rpclib, rpclib.unix, forkexec, stdext, http-svr, xcp-inventory, network-libs, xen-api-client, xcp, xcp.network
+  build-deps: threads, rpclib, rpclib.unix, forkexec, stdext, xcp-inventory, network-libs, xen-api-client, xcp, xcp.network
   pp: camlp4o
 
 executable networkd_db


### PR DESCRIPTION
networkd has been using cohttp via xcp-idl since commit
e6b2f0774b71683b4a970ce64c96e6d31f11e488
