### PR TITLE
CA-120846: fix get_mac for bonded interfaces

### DIFF
--- a/networkd/network_server.ml
+++ b/networkd/network_server.ml
@@ -103,7 +103,9 @@ module Interface = struct
 
 	let get_mac _ dbg ~name =
 		Debug.with_thread_associated dbg (fun () ->
-			Ip.get_mac name
+			match Linux_bonding.get_bond_master_of name with
+			| Some master -> Proc.get_bond_slave_mac master name
+			| None -> Ip.get_mac name
 		) ()
 
 	let is_up _ dbg ~name =


### PR DESCRIPTION
When an interface is bonded by the Linux bonding driver, the driver may change
the MAC address if the interface to that of the bond. The only place where you
can find the "real" MAC address of a bond slave seems to be /proc/net/bonding.

Signed-off-by: Rob Hoes rob.hoes@citrix.com
