### PR TITLE
Don't record RRDs for the "ovs-system" interface

### DIFF
--- a/networkd/network_monitor_thread.ml
+++ b/networkd/network_monitor_thread.ml
@@ -115,7 +115,8 @@ let get_link_stats () =
 		not(String.startswith "dummy" name) &&
 			not(String.startswith "xenbr" name) &&
 			not(String.startswith "xapi" name) &&
-			not(String.startswith "eth" name && String.contains name '.')
+			not(String.startswith "eth" name && String.contains name '.') &&
+			name <> "ovs-system"
 	) devs in
 
 	Cache.free cache;


### PR DESCRIPTION
This started appearing in the recent single-datapath OVSes, but does not really
add anything useful.

Signed-off-by: Rob Hoes rob.hoes@citrix.com
