### PR TITLE
CA-140402: set max-idle to 5000ms on OVS

### DIFF
--- a/lib/network_utils.ml
+++ b/lib/network_utils.ml
@@ -663,6 +663,12 @@ module Ovs = struct
 			nb_links
 		with _ -> 0
 
+	let set_max_idle t =
+		try
+			ignore (vsctl ["set"; "Open_vSwitch"; "."; Printf.sprintf "other_config:max-idle=%d" t])
+		with _ ->
+			warn "Failed to set max-idle=%d on OVS" t
+
 	let handle_vlan_bug_workaround override bridge =
 		(* This is a list of drivers that do support VLAN tx or rx acceleration, but
 		 * to which the VLAN bug workaround should not be applied. This could be

--- a/networkd/network_server.ml
+++ b/networkd/network_server.ml
@@ -769,6 +769,8 @@ let on_startup () =
 			(* the following is best-effort *)
 			read_config ();
 			remove_centos_config ();
+			if !Bridge.kind = Openvswitch then
+				Ovs.set_max_idle 5000;
 			Bridge.make_config () dbg ~conservative:true ~config:!config.bridge_config ();
 			Interface.make_config () dbg ~conservative:true ~config:!config.interface_config ();
 			(* If there is still a network.dbcache file, move it out of the way. *)


### PR DESCRIPTION
Max-idle is an OVS setting that determines the idle timeout of flows in the
kernel.  Upstream OVS had reduced the timeout from 5000ms to 1500ms, causing
kernel flows to be removed sooner. For flows that send packets with an interval
that is a little larger than 1500ms, this means that every packet will result
in an upcall to the OVS userspace. Tests have shown a relatively large impact
on the dom0 CPU usage due to the reduced timeout.

This patch puts the max-idle timeout back to 5000ms. Do this in xcp-networkd
when it starts up.

Signed-off-by: Rob Hoes rob.hoes@citrix.com
