### PR TITLE
CA-127274: Linux bridge: set forwarding delay to 0 after creating a bridge

### DIFF
--- a/lib/network_utils.ml
+++ b/lib/network_utils.ml
@@ -921,6 +921,8 @@ module Brctl = struct
 		if List.mem name (Sysfs.bridge_to_interfaces bridge) then
 			ignore (call ~log:true ["delif"; bridge; name])
 
+	let set_forwarding_delay bridge time =
+		ignore (call ~log:true ["setfd"; bridge; string_of_int time])
 end
 
 module Ethtool = struct

--- a/networkd/network_server.ml
+++ b/networkd/network_server.ml
@@ -487,6 +487,7 @@ module Bridge = struct
 					vlan vlan_bug_workaround name)
 			| Bridge ->
 				ignore (Brctl.create_bridge name);
+				Brctl.set_forwarding_delay name 0;
 				Opt.iter (Ip.set_mac name) mac;
 				match vlan with
 				| None -> ()


### PR DESCRIPTION
The forwarding delay is 30s by default, which means that for the first 30s
after bringing up a bridge port, the port will be in "learning mode", and won't
forward any packets. We want bridge ports to immediately go in "forwarding
mode" instead.

We did this in the past, but it was lost in the transition to xcp-networkd.

Signed-off-by: Rob Hoes rob.hoes@citrix.com
