### PR TITLE
CA-151464: Don't assume interface is bonded if master sysfs key exists

### DIFF
--- a/lib/network_utils.ml
+++ b/lib/network_utils.ml
@@ -456,8 +456,13 @@ module Linux_bonding = struct
 
 	let get_bond_master_of slave =
 		try
-			let path = Unix.readlink (Sysfs.getpath slave "master") in
-			Some (List.hd (List.rev (String.split '/' path)))
+			let master_symlink = Sysfs.getpath slave "master" in
+			let master_path = Unix.readlink master_symlink in
+			let slaves_path = Filename.concat master_symlink "bonding/slaves" in
+			let slaves = Sysfs.read_one_line slaves_path |> String.split ' ' in
+			if List.mem slave slaves
+			then Some (List.hd (List.rev (String.split '/' master_path)))
+			else None
 		with _ -> None
 end
 

--- a/lib/network_utils.ml
+++ b/lib/network_utils.ml
@@ -459,10 +459,8 @@ module Linux_bonding = struct
 			let master_symlink = Sysfs.getpath slave "master" in
 			let master_path = Unix.readlink master_symlink in
 			let slaves_path = Filename.concat master_symlink "bonding/slaves" in
-			let slaves = Sysfs.read_one_line slaves_path |> String.split ' ' in
-			if List.mem slave slaves
-			then Some (List.hd (List.rev (String.split '/' master_path)))
-			else None
+			Unix.access slaves_path [ Unix.F_OK ];
+			Some (List.hd (List.rev (String.split '/' master_path)))
 		with _ -> None
 end
 


### PR DESCRIPTION
In 3.12+ kernels, this key also exists for OVS ports.

Signed-off-by: Si Beaumont <simon.beaumont@citrix.com>