### PR TITLE
CP-9895: Added originator for xapi login_with_password

### DIFF
--- a/networkd/network_monitor_thread.ml
+++ b/networkd/network_monitor_thread.ml
@@ -35,7 +35,7 @@ let send_bond_change_alert dev interfaces message =
 	let ifaces = String.concat "+" (List.sort String.compare interfaces) in
 	let module XenAPI = Client.Client in
 	let session_id = XenAPI.Session.login_with_password
-		~rpc:xapi_rpc ~uname:"" ~pwd:"" ~version:"1.4" in
+		~rpc:xapi_rpc ~uname:"" ~pwd:"" ~version:"1.4" ~originator:("xcp-networkd v" ^ Version.version) in
 	Pervasiveext.finally
 		(fun _ ->
 			let obj_uuid = Inventory.lookup Inventory._installation_uuid in


### PR DESCRIPTION
The login_with_password XenAPI call takes an "originator"
string as its fourth parameter.

If a client does this, then it gets its own pool of xapi sessions.
Moreover it will not have its xapi sessions destroyed prematurely
as a result of some other misbehaving client that keeps creating
sessions and not logging out of them.

This patch adds the "originator" to all invokes of
login_with_password.

Signed-off-by: Koushik Chakravarty <koushik.chakravarty@citrix.com>