### PR TITLE
Use a switch `--xapi` to call fcoe driver

### DIFF
--- a/lib/network_utils.ml
+++ b/lib/network_utils.ml
@@ -33,7 +33,7 @@ let modprobe = "/sbin/modprobe"
 let ethtool = ref "/sbin/ethtool"
 let bonding_dir = "/proc/net/bonding/"
 let dhcp6c = "/sbin/dhcp6c"
-let fcoedriver = ref "/opt/xensource/libexec/fcoe_driver.py"
+let fcoedriver = ref "/opt/xensource/libexec/fcoe_driver"
 
 let call_script ?(log_successful_output=false) script args =
 	try

--- a/lib/network_utils.ml
+++ b/lib/network_utils.ml
@@ -553,7 +553,7 @@ module Fcoe = struct
 
 	let get_capabilities name =
 		try
-			let output = call [name; "capable"] in
+			let output = call ["--xapi"; name; "capable"] in
 			if String.has_substr output "True" then ["fcoe"] else []
                 with _ ->
                         debug "Failed to get fcoe support status on device %s" name;


### PR DESCRIPTION
Signed-off-by: Sharad Yadav <sharad.yadav@citrix.com>