### PR TITLE
Start xcp-networkd with priority 14

### DIFF
--- a/scripts/init.d-networkd
+++ b/scripts/init.d-networkd
@@ -2,7 +2,7 @@
 #
 # xcp-networkd     Start/Stop the XCP networking daemon
 #
-# chkconfig: 2345 13 76
+# chkconfig: 2345 14 76
 # description: XCP networking daemon
 # processname: xcp-networkd
 # pidfile: /var/run/xcp-networkd.pid


### PR DESCRIPTION
This ensures that xcp-networkd is started after forkexecd, which has a start
priority of 13 (since 97cc4745 in forkexecd.git).

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>