### PR TITLE
CP-15312: Remove dhcp6 exception from toolstack startup

### DIFF
--- a/lib/network_utils.ml
+++ b/lib/network_utils.ml
@@ -32,7 +32,6 @@ let brctl = ref "/sbin/brctl"
 let modprobe = "/sbin/modprobe"
 let ethtool = ref "/sbin/ethtool"
 let bonding_dir = "/proc/net/bonding/"
-let dhcp6c = "/sbin/dhcp6c"
 let fcoedriver = ref "/opt/xensource/libexec/fcoe_driver"
 
 let call_script ?(log_successful_output=false) ?(timeout=Some 60.0) script args =
@@ -985,15 +984,4 @@ module Bindings = struct
 		try
 			with_fd (fun fd -> _get_status fd name)
 		with _ -> raise (Read_error "stub_link_get_status")
-end
-
-module Dhcp6c = struct
-	let pid_file interface =
-		Printf.sprintf "/var/run/dhcp6c-%s.pid" interface
-
-	let start interface =
-		ignore (call_script dhcp6c [interface])
-
-	let stop interface =
-		ignore (call_script dhcp6c ["-r"; "all"; interface])
 end

--- a/networkd/network_server.ml
+++ b/networkd/network_server.ml
@@ -193,31 +193,36 @@ module Interface = struct
 			match conf with
 			| None6 ->
 				if List.mem name (Sysfs.list ()) then begin
-					Dhcp6c.stop name;
+					if Dhclient.is_running ~ipv6:true name then
+						ignore (Dhclient.stop ~ipv6:true name);
 					Sysctl.set_ipv6_autoconf name false;
 					Ip.flush_ip_addr ~ipv6:true name
 				end
 			| Linklocal6 ->
 				if List.mem name (Sysfs.list ()) then begin
-					Dhcp6c.stop name;
+					if Dhclient.is_running ~ipv6:true name then
+						ignore (Dhclient.stop ~ipv6:true name);
 					Sysctl.set_ipv6_autoconf name false;
 					Ip.flush_ip_addr ~ipv6:true name;
 					Ip.set_ipv6_link_local_addr name
 				end
 			| DHCP6 ->
-				Dhcp6c.stop name;
+				if Dhclient.is_running ~ipv6:true name then
+					ignore (Dhclient.stop ~ipv6:true name);
 				Sysctl.set_ipv6_autoconf name false;
 				Ip.flush_ip_addr ~ipv6:true name;
 				Ip.set_ipv6_link_local_addr name;
-				Dhcp6c.start name
+				ignore (Dhclient.start ~ipv6:true name [])
 			| Autoconf6 ->
-				Dhcp6c.stop name;
+				if Dhclient.is_running ~ipv6:true name then
+					ignore (Dhclient.stop ~ipv6:true name);
 				Ip.flush_ip_addr ~ipv6:true name;
 				Ip.set_ipv6_link_local_addr name;
 				Sysctl.set_ipv6_autoconf name true;
 				(* Cannot link set down/up due to CA-89882 - IPv4 default route cleared *)
 			| Static6 addrs ->
-				Dhcp6c.stop name;
+				if Dhclient.is_running ~ipv6:true name then
+					ignore (Dhclient.stop ~ipv6:true name);
 				Sysctl.set_ipv6_autoconf name false;
 				Ip.flush_ip_addr ~ipv6:true name;
 				Ip.set_ipv6_link_local_addr name;


### PR DESCRIPTION
dhclient handles all ipv6 related configurations and hence dhcp6
is not required

Signed-off-by: Koushik Chakravarty <koushik.chakravarty@citrix.com>