### PR TITLE
CP-15745: Add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: c
+services: docker
+install:
+    - wget https://raw.githubusercontent.com/xenserver/xenserver-build-env/master/utils/travis-build-repo.sh
+script: bash travis-build-repo.sh
+sudo: true
+env:
+    global:
+        - REPO_PACKAGE_NAME=xcp-networkd
+        - REPO_CONFIGURE_CMD=true
+        - REPO_BUILD_CMD=make
+        - REPO_TEST_CMD='make test'


### PR DESCRIPTION
This will build and test xcp-networkd using the new xenserver-build-env
build scripts.