### PR TITLE
CA-208547: Revert "CA-206909: Write PID file after finishing startup activities"

### DIFF
--- a/networkd/networkd.ml
+++ b/networkd/networkd.ml
@@ -94,15 +94,15 @@ let _ =
 		~rpc_fn:(Server.process ())
 		() in
 
-	Xcp_service.maybe_daemonize ~start_fn:(fun () ->
-		Debug.set_facility Syslog.Local5;
+	Xcp_service.maybe_daemonize ();
 
-		(* We should make the following configurable *)
-		Debug.disable "http";
+	Debug.set_facility Syslog.Local5;
 
-		handle_shutdown ();
-		Debug.with_thread_associated "main" start server
-	) ();
+	(* We should make the following configurable *)
+	Debug.disable "http";
+
+	handle_shutdown ();
+	Debug.with_thread_associated "main" start server;
 
 	while true do
 		Thread.delay 300.;


### PR DESCRIPTION
If networkd takes too long to get the point where it writes its pidfile
then systemd will kill it, leaving the host in a broken state.

This reverts commit f11fd4a735b2d807a25269c9fe91758c560e5e3c.