### PR TITLE
CA-210762: Linux bridge: Always update bond properties

### DIFF
--- a/networkd/network_server.ml
+++ b/networkd/network_server.ml
@@ -727,20 +727,17 @@ module Bridge = struct
 				if List.length interfaces = 1 then
 					List.iter (fun name -> Interface.bring_up () dbg ~name) interfaces
 				else begin
-					if not (List.mem name (Sysfs.bridge_to_interfaces bridge)) then begin
-						Linux_bonding.add_bond_master name;
-						let bond_properties =
-							if List.mem_assoc "mode" bond_properties && List.assoc "mode" bond_properties = "lacp" then
-								List.replace_assoc "mode" "802.3ad" bond_properties
-							else bond_properties
-						in
-						Linux_bonding.set_bond_properties name bond_properties;
-						List.iter (fun name -> Interface.bring_down () dbg ~name) interfaces;
-						List.iter (Linux_bonding.add_bond_slave name) interfaces;
-						begin match bond_mac with
-							| Some mac -> Ip.set_mac name mac
-							| None -> warn "No MAC address specified for the bond"
-						end
+					Linux_bonding.add_bond_master name;
+					let bond_properties =
+						if List.mem_assoc "mode" bond_properties && List.assoc "mode" bond_properties = "lacp" then
+							List.replace_assoc "mode" "802.3ad" bond_properties
+						else bond_properties
+					in
+					Linux_bonding.set_bond_properties name bond_properties;
+					Linux_bonding.set_bond_slaves name interfaces;
+					begin match bond_mac with
+						| Some mac -> Ip.set_mac name mac
+						| None -> warn "No MAC address specified for the bond"
 					end;
 					Interface.bring_up () dbg ~name
 				end;


### PR DESCRIPTION
Bond properties such as the bond mode were not updated if the bond already
existed. This caused XenAPI commands such as Bond.set_mode to have no immediate
effect (changes would be implemented only after re-plugging or rebooting).

Also make sure that bond-manipulation functions in Network_utils are idempotent,
as the high-level function call is supposed to be idempotent.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>