### PR TITLE
CA-211448: When reading a line from sysfs, translate End_of_file to ""

### DIFF
--- a/lib/network_utils.ml
+++ b/lib/network_utils.ml
@@ -82,7 +82,9 @@ module Sysfs = struct
 			let result = input_line inchan in
 			close_in inchan;
 			result
-		with exn -> close_in inchan; raise (Read_error file)
+		with
+		| End_of_file -> close_in inchan; ""
+		| exn -> error "%s" (Printexc.to_string exn); close_in inchan; raise (Read_error file)
 
 	let write_one_line file l =
 		let outchan = open_out file in

--- a/lib/network_utils.ml
+++ b/lib/network_utils.ml
@@ -77,14 +77,14 @@ module Sysfs = struct
 		Printf.sprintf "/sys/class/net/%s/%s" dev attr
 
 	let read_one_line file =
-		let inchan = open_in file in
 		try
-			let result = input_line inchan in
-			close_in inchan;
-			result
+			let inchan = open_in file in
+			finally
+				(fun () -> input_line inchan)
+				(fun () -> close_in inchan)
 		with
-		| End_of_file -> close_in inchan; ""
-		| exn -> error "%s" (Printexc.to_string exn); close_in inchan; raise (Read_error file)
+		| End_of_file -> ""
+		| exn -> error "%s" (Printexc.to_string exn); raise (Read_error file)
 
 	let write_one_line file l =
 		let outchan = open_out file in


### PR DESCRIPTION
Some sysfs files are "empty", for a good reason.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>