### PR TITLE
Don't collect stats for loopback and bond devices

### DIFF
--- a/networkd/network_monitor_thread.ml
+++ b/networkd/network_monitor_thread.ml
@@ -31,6 +31,8 @@ let monitor_blacklist = ref [
 	"xapi";
 	"ovs-system";
 	"xenapi";
+	"lo";
+	"bond";
 ]
 
 let xapi_rpc request =


### PR DESCRIPTION
We don't use the stats for these devices, so lets not spend time on them.

Furthermore, due to the fact that the Sysfs.read_one_line and therefore the
Sysfs.get_pci_ids function now log errors, and the loopback and bond devices
do not have PCI info in sysfs, this was causing lots of log spam.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>