### PR TITLE
CA-201728: Add new function `is_vlan_in_use`

### DIFF
--- a/lib/network_utils.ml
+++ b/lib/network_utils.ml
@@ -674,6 +674,19 @@ module Proc = struct
 		else
 			raise Not_found
 
+let get_vlans () =
+	try
+		Unixext.file_lines_fold (fun vlans line ->
+			try
+				let x = Scanf.sscanf line "%s | %d | %s" (fun device vlan parent -> device, vlan, parent) in
+				x :: vlans
+			with _ ->
+				vlans
+			) [] "/proc/net/vlan/config"
+	with e ->
+		error "Error: could not read /proc/net/vlan/config";
+		[]
+
 	let get_bond_links_up name =
 		let statusses = get_bond_slave_info name "MII Status" in
 		List.fold_left (fun x (_, y) -> x + (if y = "up" then 1 else 0)) 0 statusses


### PR DESCRIPTION
Function `is_vlan_in_use` will identify the VLAN which is
in use by FCoE and unknown to XAPI.

Signed-off-by: sharad yadav <sharad.yadav@citrix.com>