### PR TITLE
Set no-flood on PVS-proxy ports

### DIFF
--- a/lib/network_utils.ml
+++ b/lib/network_utils.ml
@@ -1027,6 +1027,10 @@ module Ovs = struct
 				) ports)
 		in
 		List.iter (fun flow -> ignore (ofctl ~log:true ["add-flow"; bridge; flow])) flows
+
+	let mod_port bridge port action =
+		ofctl ~log:true ["mod-port"; bridge; port; action] |> ignore
+
 	end
 	include Make(Cli)
 end

--- a/networkd/network_server.ml
+++ b/networkd/network_server.ml
@@ -774,6 +774,7 @@ module Bridge = struct
 		match !backend_kind with
 		| Openvswitch ->
 			ignore (Ovs.create_port ~internal:true name bridge);
+			Ovs.mod_port bridge name "no-flood";
 			Interface.bring_up () dbg ~name
 		| Bridge ->
 			raise Not_implemented


### PR DESCRIPTION
This adds some protection against unicast floods (which happen as part of MAC
learning) getting out of hand.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>