### PR TITLE
CA-225272: rate-limit calls to `ovs-vsctl`

### DIFF
--- a/lib/network_utils.ml
+++ b/lib/network_utils.ml
@@ -706,8 +706,11 @@ end
 module Ovs = struct
 
 	module Cli = struct
+	let s = Semaphore.create 7
 	let vsctl ?(log=false) args =
-		call_script ~log_successful_output:log ovs_vsctl ("--timeout=20" :: args)
+		Semaphore.execute s (fun () ->
+			call_script ~log_successful_output:log ovs_vsctl ("--timeout=20" :: args)
+		)
 	let ofctl ?(log=false) args =
 		call_script ~log_successful_output:log ovs_ofctl args
 	let appctl ?(log=false) args =

--- a/lib/network_utils.ml
+++ b/lib/network_utils.ml
@@ -705,8 +705,12 @@ end
 
 module Ovs = struct
 
-	module Cli = struct
-	let s = Semaphore.create 7
+	module Cli : sig
+		val vsctl : ?log:bool -> string list -> string
+		val ofctl : ?log:bool -> string list -> string
+		val appctl : ?log:bool -> string list -> string
+	end = struct
+	let s = Semaphore.create 5
 	let vsctl ?(log=false) args =
 		Semaphore.execute s (fun () ->
 			call_script ~log_successful_output:log ovs_vsctl ("--timeout=20" :: args)


### PR DESCRIPTION
OVSDB server can handle at most 10 connections at a time, to avoid issues we rate-limit the number of concurrent connections. The limit is lower than 10 because we need to take into account the possibility of calls from other scripts.

This will not compile until https://github.com/xapi-project/stdext/pull/17 is merged