### PR TITLE
CA-234506: Don't lose the port `kind` param in bridge.make_config

### DIFF
--- a/networkd/network_server.ml
+++ b/networkd/network_server.ml
@@ -891,8 +891,8 @@ module Bridge = struct
 				update_config bridge_name c;
 				exec (fun () ->
 					create () dbg ?vlan ?mac:bridge_mac ~other_config ~name:bridge_name ();
-					List.iter (fun (port_name, {interfaces; bond_properties; bond_mac}) ->
-						add_port () dbg ?bond_mac ~bridge:bridge_name ~name:port_name ~interfaces ~bond_properties ()
+					List.iter (fun (port_name, {interfaces; bond_properties; bond_mac; kind}) ->
+						add_port () dbg ?bond_mac ~bridge:bridge_name ~name:port_name ~interfaces ~bond_properties ~kind ()
 					) ports
 				)
 			) config


### PR DESCRIPTION
This (relatively new) kind parameter was not passed on to the function that
adds the port to the bridge, so that it would add a port of the wrong kind.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>