### PR TITLE
CA-223676: Add function `get_physical_interfaces` to networkd

### DIFF
--- a/lib/network_utils.ml
+++ b/lib/network_utils.ml
@@ -776,6 +776,11 @@ module Ovs = struct
 			debug "bridge_to_vlan: %s" (Printexc.to_string e);
 			None
 
+	let get_real_bridge name =
+		match bridge_to_vlan name with
+		| Some (parent, vlan) -> parent
+		| None -> name
+
 	let get_bond_link_status name =
 		try
 			let raw = appctl ["bond/show"; name] in


### PR DESCRIPTION
This function will provide the physical interfaces underneath
the bridge.
Bridge can be on:
1) Physical interface.
2) VLAN on physical interface.
3) On a bond.
4) VLAN on a bond.

Signed-off-by: Sharad Yadav <sharad.yadav@citrix.com>