### PR TITLE
CA-250444: Always flush addresses when switching from DHCP to static

### DIFF
--- a/networkd/network_server.ml
+++ b/networkd/network_server.ml
@@ -173,8 +173,10 @@ module Interface = struct
 				let options = gateway @ dns in
 				Dhclient.ensure_running name options
 			| Static4 addrs ->
-				if Dhclient.is_running name then
+				if Dhclient.is_running name then begin
 					ignore (Dhclient.stop name);
+					Ip.flush_ip_addr name
+				end;
 				(* the function is meant to be idempotent and we
 				 * want to avoid CA-239919 *)
 				let cur_addrs = Ip.get_ipv4 name in


### PR DESCRIPTION
dhclient now sets limited address lifetimes on DHCP-allocated addresses:

7: xenbr0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UNKNOWN qlen 1
    link/ether 18:a9:9b:23:e8:af brd ff:ff:ff:ff:ff:ff
    inet 10.71.152.106/21 brd 10.71.159.255 scope global dynamic xenbr0
       valid_lft 16017sec preferred_lft 16017sec

If we switch from DHCP to static addressing using the same IP address,
xcp-networkd will see that the address is already assigned to the
interface and will not update it.   Without dhclient updating the lifetime
timer, the address will eventually time out and the kernel will remove it.

To avoid this problem, we now flush all an interface's addresses when
switching from DHCP to static addressing, then re-add the static address.
This results in the lifetime being set to 'forever':

7: xenbr0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UNKNOWN qlen 1
    link/ether 18:a9:9b:23:e8:af brd ff:ff:ff:ff:ff:ff
    inet 10.71.152.106/21 brd 10.71.159.255 scope global xenbr0
       valid_lft forever preferred_lft forever

Signed-off-by: Euan Harris <euan.harris@citrix.com>