### PR TITLE
CA-254379: Fixing vlan bridge create during host installation.

### DIFF
--- a/lib/network_config.ml
+++ b/lib/network_config.ml
@@ -76,20 +76,24 @@ let read_management_conf () =
 				ports = [device, {default_port with interfaces = [device]}];
 				persistent_b = true
 				} in
-			match vlan with
-			| None ->
-				[device, phy_interface; bridge_name, bridge_interface],
-				[bridge_name, primary_bridge_conf]
-			| Some vlan ->
-				let parent = bridge_naming_convention device in
-				let secondary_bridge_conf = {default_bridge with
-					vlan = Some (parent, int_of_string vlan);
-					bridge_mac = (Some mac);
-					persistent_b = true
-				} in
-				let parent_bridge_interface = {default_interface with persistent_i = true} in
-				[device, phy_interface; parent, parent_bridge_interface; bridge_name, bridge_interface],
-				[parent, primary_bridge_conf; bridge_name, secondary_bridge_conf]
+			if bridge_name = "" then
+				[], []
+			else begin
+				match vlan with
+				| None ->
+					[device, phy_interface; bridge_name, bridge_interface],
+					[bridge_name, primary_bridge_conf]
+				| Some vlan ->
+					let parent = bridge_naming_convention device in
+					let secondary_bridge_conf = {default_bridge with
+						vlan = Some (parent, int_of_string vlan);
+						bridge_mac = (Some mac);
+						persistent_b = true
+					} in
+					let parent_bridge_interface = {default_interface with persistent_i = true} in
+					[device, phy_interface; parent, parent_bridge_interface; bridge_name, bridge_interface],
+					[parent, primary_bridge_conf; bridge_name, secondary_bridge_conf]
+			end
 		in
 		{interface_config = interface_config; bridge_config = bridge_config;
 			gateway_interface = Some bridge_name; dns_interface = Some bridge_name}


### PR DESCRIPTION
Host installer doesn't write management_interface into inventory.
As firstboot needs to create management pif and update the inventory.

In case of management on vlan xcp-networkd must not create vlan bridge
if management_interface is empty.
Let the firstboot create the VLAN and set the management PIF.

Signed-off-by: Sharad Yadav <sharad.yadav@citrix.com>