### PR TITLE
CP-23843: Disable IPv6 multicast snooping for OVS in XenServer

### DIFF
--- a/lib/network_utils.ml
+++ b/lib/network_utils.ml
@@ -38,6 +38,7 @@ let fcoedriver = ref "/opt/xensource/libexec/fcoe_driver"
 let inject_igmp_query_script = ref "/usr/libexec/xenopsd/igmp_query_injector.py"
 let mac_table_size = ref 10000
 let igmp_query_maxresp_time = ref "5000"
+let enable_ipv6_mcast_snooping = ref false
 
 let call_script ?(log_successful_output=false) ?(timeout=Some 60.0) script args =
 	try
@@ -935,8 +936,12 @@ module Ovs = struct
 			| Some x, None -> ["--"; "set"; "bridge"; name; "mcast_snooping_enable=" ^ (string_of_bool x)]
 			| _ -> []
 		in
+		let set_ipv6_igmp_snooping = match igmp_snooping, vlan with
+			| Some _, None -> ["--"; "set"; "bridge"; name; "other_config:enable-ipv6-mcast-snooping=" ^ (string_of_bool !enable_ipv6_mcast_snooping)]
+			| _ -> []
+		in
 		vsctl ~log:true (del_old_arg @ ["--"; "--may-exist"; "add-br"; name] @
-			vlan_arg @ mac_arg @ fail_mode_arg @ disable_in_band_arg @ external_id_arg @ vif_arg @ set_mac_table_size @ set_igmp_snooping)
+			vlan_arg @ mac_arg @ fail_mode_arg @ disable_in_band_arg @ external_id_arg @ vif_arg @ set_mac_table_size @ set_igmp_snooping @ set_ipv6_igmp_snooping)
 
 	let destroy_bridge name =
 		vsctl ~log:true ["--"; "--if-exists"; "del-br"; name]

--- a/networkd/networkd.ml
+++ b/networkd/networkd.ml
@@ -62,6 +62,7 @@ let options = [
 	"enic-workaround-until-version", Arg.Set_string Network_server.enic_workaround_until_version, (fun () -> !Network_server.enic_workaround_until_version), "The version till enic driver workaround will be applied or the version set to an empty string for not applying the workaround.";
 	"pvs-proxy-socket", Arg.Set_string Network_server.PVS_proxy.path, (fun () -> !Network_server.PVS_proxy.path), "Path to the Unix domain socket for the PVS-proxy daemon";
 	"igmp-query-maxresp-time", Arg.Set_string Network_utils.igmp_query_maxresp_time, (fun () -> !Network_utils.igmp_query_maxresp_time), "Maximum Response Time in IGMP Query message to send";
+	"enable-ipv6-mcast-snooping", Arg.Bool (fun x -> Network_utils.enable_ipv6_mcast_snooping := x), (fun () -> string_of_bool !Network_utils.enable_ipv6_mcast_snooping), "IPv6 multicast snooping toggle";
 ]
 
 let start server =


### PR DESCRIPTION
CP-23098 implemented a new OVS toggle `enable-ipv6-mcast-snooping` and set its default value to `true` for ensuring compatible with OVS.
This PR make the default value of this toggle to `false` because XenServer do not support IPv6 multicast snooping.

Signed-off-by: Yang Qian <yang.qian@citrix.com>