### PR TITLE
CP-23835: Disable flooding of unregistered traffic

### DIFF
--- a/networkd/networkd.ml
+++ b/networkd/networkd.ml
@@ -63,6 +63,7 @@ let options = [
 	"pvs-proxy-socket", Arg.Set_string Network_server.PVS_proxy.path, (fun () -> !Network_server.PVS_proxy.path), "Path to the Unix domain socket for the PVS-proxy daemon";
 	"igmp-query-maxresp-time", Arg.Set_string Network_utils.igmp_query_maxresp_time, (fun () -> !Network_utils.igmp_query_maxresp_time), "Maximum Response Time in IGMP Query message to send";
 	"enable-ipv6-mcast-snooping", Arg.Bool (fun x -> Network_utils.enable_ipv6_mcast_snooping := x), (fun () -> string_of_bool !Network_utils.enable_ipv6_mcast_snooping), "IPv6 multicast snooping toggle";
+	"mcast-snooping-disable-flood-unregistered", Arg.Bool (fun x -> Network_utils.mcast_snooping_disable_flood_unregistered := x), (fun () -> string_of_bool !Network_utils.mcast_snooping_disable_flood_unregistered), "Set OVS bridge configuration mcast-snooping-disable-flood-unregistered as 'true' or 'false'";
 ]
 
 let start server =


### PR DESCRIPTION
Disable flooding of unregistered multicast traffic by default in XenServer
Signed-off-by: Ming Lu <ming.lu@citrix.com>
Signed-off-by: Yang Qian <yang.qian@citrix.com>