### PR TITLE
CP-24074 Implement UT for inject igmp query when turn on igmp snooping

### DIFF
--- a/lib/network_utils.ml
+++ b/lib/network_utils.ml
@@ -39,7 +39,15 @@ let inject_igmp_query_script = ref "/usr/libexec/xenopsd/igmp_query_injector.py"
 let mac_table_size = ref 10000
 let igmp_query_maxresp_time = ref "5000"
 
+let in_unit_test = ref false
+let unit_test_call_script = ref ""
+
 let call_script ?(log_successful_output=false) ?(timeout=Some 60.0) script args =
+	if !in_unit_test then begin
+		unit_test_call_script := (String.concat " " (script::args));
+		!unit_test_call_script
+	end
+	else
 	try
 		Unix.access script [ Unix.X_OK ];
 		(* Use the same $PATH as xapi *)

--- a/test/network_test.ml
+++ b/test/network_test.ml
@@ -18,6 +18,7 @@ let base_suite =
 	"base_suite" >:::
 		[
 			Network_test_lacp_properties.suite;
+			Network_test_igmp.suite;
 			Test_jsonrpc_client.suite;
 		]
 

--- a/test/network_test_igmp.ml
+++ b/test/network_test_igmp.ml
@@ -1,0 +1,65 @@
+(*
+ * Copyright (C) 2006-2013 Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+open OUnit
+open Network_utils
+
+module OVS_Cli_test = struct
+	include Ovs.Cli
+	let vsctl_output = ref []
+	let vsctl ?(log=true) args =
+		vsctl_output := args ;
+		String.concat " " args
+end
+
+(* Test OVS.create_bridge for setting mcast_snooping_enable to OVS when carried igmp_snooping value *)
+let test_create_bridge () = 
+	let module Ovs = Ovs.Make(OVS_Cli_test) in
+	let bridge = "xapi1" in
+	let expect = "mcast_snooping_enable=true" in
+	ignore (Ovs.create_bridge ?mac:None ~fail_mode:"test_mode" ?external_id:None ?disable_in_band:None ?igmp_snooping:(Some true)
+			None (Some false) bridge);
+
+	assert_bool "Missing IGMP Snooping toggle!"
+		(List.exists
+			(fun s -> (s = expect))
+			!OVS_Cli_test.vsctl_output)
+
+(* Test OVS.get_mcast_snooping_enable to form the correct parameter to query OVS *)
+let test_get_mcast_snooping_enable () = 
+	let module Ovs = Ovs.Make(OVS_Cli_test) in
+	let bridge = "xapi1" in
+	let expect = "-- get bridge xapi1 mcast_snooping_enable" in
+	ignore (Ovs.get_mcast_snooping_enable bridge);
+
+	assert_bool "Incorrect input format!"
+		((String.concat " " !OVS_Cli_test.vsctl_output) = expect)
+
+(* Test the function form correct format to invoke the script to inject IGMP Query *)
+let test_inject_igmp_query () =
+	Network_utils.in_unit_test := true;
+	let bridge = "xapi1" in
+	let expect = "/usr/libexec/xenopsd/igmp_query_injector.py --detach --max-resp-time 5000 bridge xapi1" in
+	ignore (Ovs.inject_igmp_query bridge);
+
+	assert_bool "Incorrect script call format!"
+	(!Network_utils.unit_test_call_script = expect)
+
+let suite =
+	"igmp_tests" >:::
+		[
+			"test_create_bridge" >:: test_create_bridge;
+			"test_get_mcast_snooping_enable" >:: test_get_mcast_snooping_enable;
+			"test_inject_igmp_query" >:: test_inject_igmp_query;
+		]


### PR DESCRIPTION
Added three Unit test cases to test OVS.create_bridge, OVS.get_mcast_snooping_enable and OVS.inject_igmp_query.

Signed-off-by: Yarsin He <yarsin.he@citrix.com>