### PR TITLE
CA-196520: use `mtu_request` in OVS to set interface MTU

### DIFF
--- a/lib/network_utils.ml
+++ b/lib/network_utils.ml
@@ -1119,6 +1119,9 @@ module Ovs = struct
 	let mod_port bridge port action =
 		ofctl ~log:true ["mod-port"; bridge; port; action] |> ignore
 
+	let set_mtu interface mtu =
+		vsctl ~log:true ["set"; "interface"; interface; Printf.sprintf "mtu_request=%d" mtu]
+
 	end
 	include Make(Cli)
 end

--- a/networkd/network_server.ml
+++ b/networkd/network_server.ml
@@ -346,7 +346,9 @@ module Interface = struct
 		Debug.with_thread_associated dbg (fun () ->
 			debug "Configuring MTU for %s: %d" name mtu;
 			update_config name {(get_config name) with mtu};
-			ignore (Ip.link_set_mtu name mtu)
+			match !backend_kind with
+			| Openvswitch -> ignore (Ovs.set_mtu name mtu)
+			| Bridge -> Ip.link_set_mtu name mtu
 		) ()
 
 	let set_ethtool_settings _ dbg ~name ~params =


### PR DESCRIPTION
If `ip link set` is used OVS will keep changing it back to the minimum MTU if you attach 2 VLANs (created on a bond) with different MTUs to the same VM.

