### PR TITLE
CA-268679 XAPI loop report (Sys_error "Invalid argument")

### DIFF
--- a/lib/network_utils.ml
+++ b/lib/network_utils.ml
@@ -109,7 +109,12 @@ module Sysfs = struct
 				(fun () -> close_in inchan)
 		with
 		| End_of_file -> ""
-		| exn -> error "%s" (Printexc.to_string exn); raise (Read_error file)
+		(* Match the exception when the device state if off *)
+		| Sys_error("Invalid argument") -> raise (Read_error file)
+		| exn ->
+			error "Error in read one line of file: %s, exception %s\n%s"
+				file (Printexc.to_string exn) (Printexc.get_backtrace ());
+			raise (Read_error file)
 
 	let write_one_line file l =
 		let outchan = open_out file in


### PR DESCRIPTION
Match Sys_error("Invalid argument") and omit the error log.
For other error case, record the exception info and backtrace.

Signed-off-by: Yang Qian <yang.qian@citrix.com>