### PR TITLE
Mainly I changed to use Rresult for all error handle.

### DIFF
--- a/lib/jbuild
+++ b/lib/jbuild
@@ -8,6 +8,7 @@
               rpclib
               systemd
               threads
+              re.perl
               xapi-stdext-unix
               xcp-inventory
               xcp.network))

--- a/lib/network_utils.ml
+++ b/lib/network_utils.ml
@@ -46,6 +46,9 @@ let brctl = ref "/sbin/brctl"
 let modprobe = "/sbin/modprobe"
 let ethtool = ref "/sbin/ethtool"
 let bonding_dir = "/proc/net/bonding/"
+let uname = ref "/usr/bin/uname"
+let dracut = ref "/sbin/dracut"
+let dracut_timeout = ref 120.0
 let fcoedriver = ref "/opt/xensource/libexec/fcoe_driver"
 let inject_igmp_query_script = ref "/usr/libexec/xenopsd/igmp_query_injector.py"
 let mac_table_size = ref 10000
@@ -1244,4 +1247,25 @@ module Ethtool = struct
 	let set_offload name options =
 		if options <> [] then
 			ignore (call ~log:true ("-K" :: name :: (List.concat (List.map (fun (k, v) -> [k; v]) options))))
+end
+
+module Dracut = struct
+	let call ?(log=false) args =
+		call_script ~timeout:(Some !dracut_timeout) ~log_successful_output:log !dracut args
+
+	let rebuild_initrd () =
+		try
+			info "Building initrd...";
+			let img_name = call_script !uname ["-r"] |> String.trim in
+			call ["-f"; Printf.sprintf "/boot/initrd-%s.img" img_name; img_name];
+			Result.Ok ()
+		with _ -> Result.Error (Fail_to_rebuild_initrd, "Error occurs in building initrd")
+end
+
+module Modprobe = struct
+	let write_conf_file driver content=
+		try
+			Unixext.write_string_to_file (Printf.sprintf "/etc/modprobe.d/%s.conf" driver) (String.concat "\n" content);
+			Result.Ok ()
+		with _ -> Result.Error (Fail_to_write_modprobe_cfg, "Failed to write modprobe configuration file for: " ^ driver)
 end

--- a/lib/network_utils.ml
+++ b/lib/network_utils.ml
@@ -481,6 +481,22 @@ info "Found at [ %s ]" (String.concat ", " (List.map string_of_int indices));
 	let destroy_vlan name =
 		if List.mem name (Sysfs.list ()) then
 			ignore (call ~log:true ["link"; "delete"; name])
+
+	let set_vf_mac dev index mac =
+		try
+			Result.Ok (link_set dev ["vf"; string_of_int index; "mac"; mac])
+		with _ -> Result.Error (Fail_to_set_vf_mac, "Failed to set vf mac for: " ^ dev)
+
+	let set_vf_vlan dev index vlan =
+		try
+			Result.Ok (link_set dev ["vf"; string_of_int index; "vlan"; string_of_int vlan])
+		with _ -> Result.Error (Fail_to_set_vf_vlan, "Failed to set vf vlan for: " ^ dev)
+
+	(* We know some NICs do not support config VF Rate, so will explicitly tell XAPI this error*)
+	let set_vf_rate dev index rate =
+		try
+			Result.Ok (link_set dev ["vf"; string_of_int index; "mac"; string_of_int rate])
+		with _ -> Result.Error (Fail_to_set_vf_rate, "Failed to set vf rate for: " ^ dev)
 end
 
 module Linux_bonding = struct

--- a/lib/network_utils.ml
+++ b/lib/network_utils.ml
@@ -13,11 +13,26 @@
  *)
 
 open Xapi_stdext_pervasives
-
+open Xapi_stdext_unix
+open Xapi_stdext_std
 open Network_interface
 
 module D = Debug.Make(struct let name = "network_utils" end)
 open D
+
+type util_error =
+| Bus_out_of_range
+| Not_enough_mmio_resources
+| Fail_to_set_vf_rate
+| Fail_to_set_vf_vlan
+| Fail_to_set_vf_mac
+| Parent_device_of_vf_not_found
+| Vf_index_not_found
+| Fail_to_rebuild_initrd
+| Fail_to_write_modprobe_cfg
+| Fail_to_get_driver_name
+| No_sriov_capability
+| Other
 
 let iproute2 = "/sbin/ip"
 let resolv_conf = "/etc/resolv.conf"
@@ -164,6 +179,11 @@ module Sysfs = struct
 			debug "%s: could not read netdev's driver name" dev;
 			None
 
+	let get_driver_name_err dev =
+		match get_driver_name dev with
+		| Some a -> Result.Ok a
+		| None -> Result.Error (Fail_to_get_driver_name, "Failed to get driver name for: "^ dev)
+
 	(** Returns the features bitmap for the driver for [dev].
 	 *  The features bitmap is a set of NETIF_F_ flags supported by its driver. *)
 	let get_features dev =
@@ -208,6 +228,68 @@ module Sysfs = struct
 		|> (fun p -> try read_one_line p |> duplex_of_string with _ -> Duplex_unknown)
 		in (speed, duplex)
 
+	let get_dev_nums_with_same_driver driver = 
+		try
+			Sys.readdir ("/sys/bus/pci/drivers/" ^ driver)
+			|> Array.to_list
+			|> List.filter (Re.execp (Re_perl.compile_pat "\d+:\d+:\d+\.\d+"))
+			|> List.length
+		with _ -> 0
+
+	let parent_device_of_vf pcibuspath =
+		try
+			let pf_net_path = Printf.sprintf "/sys/bus/pci/devices/%s/physfn/net" pcibuspath in
+			let devices = Sys.readdir pf_net_path in
+			Result.Ok devices.(0)
+		with _ -> Result.Error (Parent_device_of_vf_not_found, "Can not get parent device for " ^ pcibuspath)
+
+	let device_index_of_vf parent_device pcibuspath =
+		try
+			let re = Re_perl.compile_pat "virtfn(\d+)" in
+			let device_path = getpath parent_device "device" in
+			let group = Sys.readdir device_path
+				|> Array.to_list
+				|> List.filter (Re.execp re) (* List elements are like "virtfn1" *)
+				|> List.find (fun x -> Xstringext.String.has_substr (Unix.readlink (device_path ^ "/" ^ x)) pcibuspath )
+				|> Re.exec_opt re
+			in
+			match group with
+			| None -> Result.Error (Vf_index_not_found, "Can not get device index for " ^ pcibuspath)
+			| Some x -> Ok (int_of_string (Re.Group.get x 1))
+		with _ -> Result.Error (Vf_index_not_found, "Can not get device index for " ^ pcibuspath)
+
+	let get_sriov_numvfs dev =
+		try
+			getpath dev "device/sriov_numvfs"
+			|> read_one_line  
+			|> String.trim
+			|> int_of_string
+		with _ -> 0
+
+	let get_sriov_maxvfs dev =
+		try
+			getpath dev "device/sriov_totalvfs"
+			|> read_one_line  
+			|> String.trim
+			|> int_of_string
+			|> fun n -> n - 1 (* maxvfs is totalvfs -1, as totalvfs is PF num + VF num *)
+		with _ -> 0
+
+	let set_sriov_numvfs dev num_vfs =
+		let interface = getpath dev "device/sriov_numvfs" in
+		let oc = open_out interface in
+		try
+			write_one_line interface (string_of_int num_vfs);
+			if get_sriov_numvfs dev = num_vfs then Result.Ok  ()
+			else Result.Error (Other, "Error: set SR-IOV error on " ^ dev)
+		with
+		| Sys_error s when Xstringext.String.has_substr s "out of range of" -> 
+			Result.Error (Bus_out_of_range, "Error: bus out of range when setting SR-IOV numvfs on " ^ dev)
+		| Sys_error s when Xstringext.String.has_substr s "not enough MMIO resources" -> 
+			Result.Error (Not_enough_mmio_resources, "Error: not enough mmio resources when setting SR-IOV numvfs on " ^ dev)
+		| e ->
+			let msg = Printf.sprintf "Error: set SR-IOV numvfs error with exception %s on %s" (Printexc.to_string e) dev in
+			Result.Error (Other, msg)
 end
 
 module Ip = struct

--- a/networkd/network_server.ml
+++ b/networkd/network_server.ml
@@ -14,6 +14,9 @@
 
 open Network_utils
 open Network_interface
+open Xapi_stdext_std
+open Xapi_stdext_unix
+open Xapi_stdext_monadic
 
 module D = Debug.Make(struct let name = "network_server" end)
 open D
@@ -123,6 +126,125 @@ let need_enic_workaround () =
 module Sriov = struct
 	let get_capabilities dev = 
 		if Sysfs.get_sriov_maxvfs dev = 0 then [] else ["sriov"]
+
+	(* To enable SR-IOV via modprobe configuration, we add a line like `options igb max_vfs=7,7,7`		
+	into the configuration. This function is meant to generate the options like `7,7,7`. the `7` have to 		
+	be repeated as many times as the number of devices with the same driver.		
+	*)
+	let gen_options_for_maxvfs driver max_vfs =
+		match Sysfs.get_dev_nums_with_same_driver driver with
+		| num when num > 0 -> Result.Ok (
+			Array.make num (string_of_int max_vfs)
+			|> Array.to_list
+			|> String.concat ",")
+		| _ -> Result.Error (Other, "Fail to generate options for maxvfs for " ^ driver)
+
+	(* For given driver like igb, we parse each line of igb.conf which is the modprobe
+	configuration for igb. We keep the same the lines that do not have SR-IOV configurations and 
+	change lines that need to be changed with patterns like `options igb max_vfs=4`
+	*)
+	let parse_modprobe_conf_internal file_path driver option =
+		let has_probe_conf = ref false in
+		let need_rebuild_initrd = ref false in
+		let parse_single_line s = 
+			let parse_driver_options s = 
+				match Xstringext.String.split ~limit:2 '=' s with
+				(* has SR-IOV configuration but the max_vfs is exactly what we want to set, so no changes and return s *)
+				| [k; v] when k = "max_vfs" && v = option ->  has_probe_conf := true; s
+				(* has SR-IOV configuration and we need change it to expected option *)
+				| [k; v] when k = "max_vfs"  -> 
+					has_probe_conf := true;
+					need_rebuild_initrd := true;
+					debug "change SR-IOV options from [%s=%s] to [%s=%s]" k v k option;
+					Printf.sprintf "max_vfs=%s" option
+				(* we do not care the lines without SR-IOV configurations *)
+				| _ -> s
+			in
+			let trimed_s = String.trim s in
+			if Re.execp (Re_perl.compile_pat ("options[ \t]+" ^ driver)) trimed_s then
+				let driver_options = Re.split (Re_perl.compile_pat "[ \t]+") trimed_s in
+				List.map parse_driver_options driver_options
+				|> String.concat " "
+			else
+				trimed_s
+		in
+		let lines = try Unixext.read_lines file_path with _ -> [] in
+		let new_conf = List.map parse_single_line lines in
+		!has_probe_conf, !need_rebuild_initrd, new_conf
+
+	(*
+	returns ( a * b * c) where
+	a indicates the probe configuration already has the max_vfs options, meaning the device doesn't support sysfs and will be configed by modprobe
+	b indicates some changes shall be made on the coniguration to enable SR-IOV to max_vfs, so we shall rebuild the initrd.
+	and c is the configurations after these changes
+	*)
+	let parse_modprobe_conf driver max_vfs =
+		try
+			let open Rresult.R.Infix in
+			let file_path = Printf.sprintf "/etc/modprobe.d/%s.conf" driver in
+			gen_options_for_maxvfs driver max_vfs >>= fun options ->
+			Result.Ok (parse_modprobe_conf_internal file_path driver options)
+		with _ -> Result.Error (Other, "Failed to parse modprobe conf for SR-IOV configuration for " ^ driver)
+
+	let enable_sriov_via_modprobe driver maxvfs has_probe_conf need_rebuild_initrd conf = 
+		let open Rresult.R.Infix in
+		match has_probe_conf, need_rebuild_initrd with
+		| true, true ->
+			Modprobe.write_conf_file driver conf >>= fun () ->
+			Dracut.rebuild_initrd ()
+		| false, false -> 
+			gen_options_for_maxvfs driver maxvfs >>= fun options ->
+			let new_option_line = Printf.sprintf "options %s max_vfs=%s" driver options in
+			Modprobe.write_conf_file driver (conf @ [new_option_line]) >>= fun () ->
+			Dracut.rebuild_initrd ()
+		| true, false -> Result.Ok () (* already have modprobe configuration and no need to change *)
+		| false, true -> Result.Error (Other, "enabling SR-IOV via modprobe never comes here for: " ^ driver)
+
+	let enable_internal dev =
+		let open Rresult.R.Infix in
+		let numvfs = Sysfs.get_sriov_numvfs dev
+		and maxvfs = Sysfs.get_sriov_maxvfs dev in
+		Sysfs.get_driver_name_err dev >>= fun driver ->
+		parse_modprobe_conf driver maxvfs >>= fun (has_probe_conf, need_rebuild_initrd, conf) ->
+		if maxvfs = 0 then Result.Error (No_sriov_capability, (Printf.sprintf "%s: do not have SR-IOV capabilities" dev)) else Ok () >>= fun () ->
+		(* We cannot first call sysfs method unconditionally for the case where the `SR-IOV hardware status` is ON and 
+		we are about to enable SR-IOV, which is the else case. It is because sysfs method to enable SR-IOV on a `SR-IOV 
+		already enabled device` will always be succuessful even if the device doesn't support sysfs. A simple example is as follows:
+
+		- a device that doesn't support sysfs
+		- enable the device via modprobe -> Hardware Status OFF
+		- reboot -> Status ON
+		- disable via modprobe before reboot -> Status ON
+		- enable via sysfs -> will return Sysfs_succesfully -> Here bug arise.*)
+		if numvfs = 0 then begin
+			debug "enable SR-IOV on a device: %s that is disabled" dev;
+			match Sysfs.set_sriov_numvfs dev maxvfs with
+			| Result.Ok _ -> Ok Sysfs_successful
+			| Result.Error (Bus_out_of_range, msg) as e ->
+				debug "%s" msg; e
+			| Result.Error (Not_enough_mmio_resources, msg) as e ->
+				debug "%s" msg; e
+			| Result.Error (_, msg) ->
+				debug "%s does not support sysfs interfaces for reason %s, trying modprobe" dev msg;
+				enable_sriov_via_modprobe driver maxvfs has_probe_conf need_rebuild_initrd conf >>= fun () ->
+				Ok Modprobe_successful_requires_reboot
+		end
+		else begin
+			debug "enable SR-IOV on a device: %s that has been already enabled" dev;
+			match has_probe_conf with
+			| false -> Ok Sysfs_successful
+			| true -> 
+				enable_sriov_via_modprobe driver maxvfs has_probe_conf need_rebuild_initrd conf >>= fun () ->
+				Ok Modprobe_successful
+		end
+
+	let enable _ dbg ~name =
+		Debug.with_thread_associated dbg (fun () ->
+			debug "Enable network SR-IOV by name: %s" name;
+			match enable_internal name with
+			| Ok t -> (Ok t:enable_result)
+			| Result.Error (_, msg) -> Error msg
+		) ()
 end
 
 module Interface = struct

--- a/networkd/network_server.ml
+++ b/networkd/network_server.ml
@@ -245,6 +245,28 @@ module Sriov = struct
 			| Ok t -> (Ok t:enable_result)
 			| Result.Error (_, msg) -> Error msg
 		) ()
+
+	let disable_internal dev =
+		let open Rresult.R.Infix in
+		Sysfs.get_driver_name_err dev >>= 
+		fun driver ->
+		parse_modprobe_conf driver 0 >>= 
+		fun (has_probe_conf, need_rebuild_intrd, conf) ->
+		match has_probe_conf,need_rebuild_intrd with
+		| false, false ->
+			Sysfs.set_sriov_numvfs dev 0
+		| true, true ->
+			Modprobe.write_conf_file driver conf >>= fun () ->
+			Dracut.rebuild_initrd ()
+		| _ -> Ok ()
+
+	let disable _ dbg ~name =
+		Debug.with_thread_associated dbg (fun () ->	
+			debug "Disable network SR-IOV by name: %s" name;
+			match disable_internal name with
+			| Ok () -> (Ok:disable_result)
+			| Result.Error (_, msg) -> Error msg
+		) ()
 end
 
 module Interface = struct

--- a/networkd/network_server.ml
+++ b/networkd/network_server.ml
@@ -267,6 +267,32 @@ module Sriov = struct
 			| Ok () -> (Ok:disable_result)
 			| Result.Error (_, msg) -> Error msg
 		) ()
+
+	let make_vf_conf_internal pcibuspath mac vlan rate =
+		let exe_except_none f = function
+			| None -> Result.Ok ()
+			| Some a -> f a
+		in
+		let open Rresult.R.Infix in
+		Sysfs.parent_device_of_vf pcibuspath >>= fun dev ->
+		Sysfs.device_index_of_vf dev pcibuspath >>= fun index ->
+		exe_except_none (Ip.set_vf_mac dev index) mac >>= fun () ->
+		exe_except_none (Ip.set_vf_vlan dev index) vlan >>= fun () ->
+		exe_except_none (Ip.set_vf_rate dev index) rate
+
+	let make_vf_config _ dbg ~pci_address ~(vf_info : Sriov.sriov_pci_t)=
+		Debug.with_thread_associated dbg (fun () ->	
+			let vlan = Opt.map Int64.to_int vf_info.vlan
+			and rate = Opt.map Int64.to_int vf_info.rate
+			and pcibuspath = Xcp_pci.string_of_address pci_address in
+			debug "Config VF with pci address: %s" pcibuspath;
+			match make_vf_conf_internal pcibuspath vf_info.mac vlan rate with
+			| Result.Ok () -> (Ok:config_result)
+			| Result.Error (Fail_to_set_vf_rate, msg) -> 
+				debug "%s" msg;
+				Error Config_vf_rate_not_supported
+			| Result.Error (_, msg) -> debug "%s" msg; Error (Unknown msg)
+		) ()
 end
 
 module Interface = struct

--- a/networkd/network_server.ml
+++ b/networkd/network_server.ml
@@ -120,6 +120,11 @@ let need_enic_workaround () =
 		| Some vs -> (is_older_version vs !enic_workaround_until_version ())
 		| None -> false )
 
+module Sriov = struct
+	let get_capabilities dev = 
+		if Sysfs.get_sriov_maxvfs dev = 0 then [] else ["sriov"]
+end
+
 module Interface = struct
 	let get_config name =
 		get_config !config.interface_config default_interface name
@@ -374,7 +379,7 @@ module Interface = struct
 
 	let get_capabilities _ dbg ~name =
 		Debug.with_thread_associated dbg (fun () ->
-			Fcoe.get_capabilities name
+			Fcoe.get_capabilities name @ Sriov.get_capabilities name
 		) ()
 
 	let is_connected _ dbg ~name =
@@ -999,28 +1004,6 @@ module Bridge = struct
 					) ports
 				)
 			) config
-		) ()
-end
-
-module Sriov = struct
-	open Xcp_pci
-
-	let enable _ dbg ~name =
-		Debug.with_thread_associated dbg (fun () ->
-			debug "Enable NET-SRIOV by name: %s" name;
-			Ok Modprobe_successful
-		) ()
-
-	let disable _ dbg ~name =
-		Debug.with_thread_associated dbg (fun () ->	
-			debug "Disable NET-SRIOV by name: %s" name;
-			Ok Modprobe_successful
-		) ()
-
-	let make_vf_config _ dbg ~pci_address ~vf_info =
-		Debug.with_thread_associated dbg (fun () ->	
-			let pcibuspath = string_of_address pci_address in
-			debug "Config VF with pci address: %s" pcibuspath;
 		) ()
 end
 

--- a/networkd/networkd.ml
+++ b/networkd/networkd.ml
@@ -61,6 +61,9 @@ let options = [
 	"igmp-query-maxresp-time", Arg.Set_string Network_utils.igmp_query_maxresp_time, (fun () -> !Network_utils.igmp_query_maxresp_time), "Maximum Response Time in IGMP Query message to send";
 	"enable-ipv6-mcast-snooping", Arg.Bool (fun x -> Network_utils.enable_ipv6_mcast_snooping := x), (fun () -> string_of_bool !Network_utils.enable_ipv6_mcast_snooping), "IPv6 multicast snooping toggle";
 	"mcast-snooping-disable-flood-unregistered", Arg.Bool (fun x -> Network_utils.mcast_snooping_disable_flood_unregistered := x), (fun () -> string_of_bool !Network_utils.mcast_snooping_disable_flood_unregistered), "Set OVS bridge configuration mcast-snooping-disable-flood-unregistered as 'true' or 'false'";
+	"uname_cmd_path", Arg.Set_string Network_utils.uname, (fun () -> !Network_utils.uname), "Path to the Unix command uname";
+	"dracut_cmd_path", Arg.Set_string Network_utils.dracut, (fun () -> !Network_utils.dracut), "Path to the Unix command dracut";
+	"dracut_timeout", Arg.Set_float Network_utils.dracut_timeout, (fun () -> string_of_float !Network_utils.dracut_timeout), "Default value for the dracut command timeout";
 ]
 
 let start server =


### PR DESCRIPTION
Since a lot of changed have been made, I raised a new PR and closed the old one. Mainly I changed to use Rresult for all error handle.

I suppose the current sriov_error defined in IDL is too complex.
Currently:

```
type sriov_error =
	| Device_not_found
	| Bus_out_of_range
	| Not_enough_mmio_resources
	| Unknown of string
```

But actually XAPI will *not* match different tags with different behaviors. So I changed it to just

```
type sriov_error =
	| Msg of string
```

## Changed list:

moved functions related to ip link to module ip.
Refined function `parent_device_of_vf`

- directly use 'devices.(0)'
- use result type instead of exception

Refined function `device_index_of_vf`

- use result type instead of exception

Add new Dracut module

Get max/num vfs from sysfs with two functions:

- Sysfs.sriov_numvfs
- Sysfs.sriov_totalvfs

Add set_sriov_numvfs into Sysfs module.

Remove get_driver function

Add Modprobe module

Disable SRIOV will return a Rresult type

Remove `open Xcp_pci`

## Unchanged list:

I tried to remove Sriov module in Network_utils, but failed as

- The functions, `parse_modprobe_conf` and `gen_options_for_maxvfs` can only be used for enabling SRIOV - they are not general Modprobe functions, so it looks not reasonable to move the two functions into Module Modprobe
- `enable_internal` depends heavily on the error I defined in `network_utils.ml`, so I am not sure if it is appropriate to move the whole function into `network_server.ml`

I haven't yet split the commit into small commits. Can I split it after the code are ready to merge.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xapi-project/xcp-networkd/126)
<!-- Reviewable:end -->
