### PR TITLE
network_config, network_server: restore semantics of split

### DIFF
--- a/lib/network_config.ml
+++ b/lib/network_config.ml
@@ -32,7 +32,7 @@ let read_management_conf () =
 		let management_conf = Xapi_stdext_unix.Unixext.string_of_file ("/etc/firstboot.d/data/management.conf") in
 		let args = Astring.String.cuts ~empty:false ~sep:"\n" (String.trim management_conf) in
 		let args = List.map (fun s ->
-			match (Astring.String.cuts ~empty:false ~sep:"=" s) with
+			match (Astring.String.cuts ~sep:"=" s) with
 			| k :: [v] -> k, Astring.String.trim ~drop:((=) '\'') v
 			| _ -> "", ""
 		) args in

--- a/networkd/network_server.ml
+++ b/networkd/network_server.ml
@@ -1033,7 +1033,7 @@ let on_startup () =
 			try
 				let file = String.trim (Xapi_stdext_unix.Unixext.string_of_file "/etc/sysconfig/network") in
 				let args = Astring.String.cuts ~empty:false ~sep:"\n" file in
-				let args = List.map (fun s -> match (Astring.String.cuts ~empty:false ~sep:"=" s) with k :: [v] -> k, v | _ -> "", "") args in
+				let args = List.map (fun s -> match (Astring.String.cuts ~sep:"=" s) with k :: [v] -> k, v | _ -> "", "") args in
 				let args = List.filter (fun (k, v) -> k <> "DNSDEV" && k <> "GATEWAYDEV") args in
 				let s = String.concat "\n" (List.map (fun (k, v) -> k ^ "=" ^ v) args) ^ "\n" in
 				Xapi_stdext_unix.Unixext.write_string_to_file "/etc/sysconfig/network" s


### PR DESCRIPTION
During the port to Astring the function `Xstringext.String.split` (that preserves empty splitted strings) has been replaced in most places by `Astring.String.cuts ~empty:false` (filtering the empty splitted strings). 

In most cases this was just an optimization. In two cases the difference in behaviour could create issues in some corner cases. This commit restores the old behavior for those.

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>