### PR TITLE
CP-26352 Port xcp-networkd from Camlp4 to PPX

### DIFF
--- a/lib/network_config.ml
+++ b/lib/network_config.ml
@@ -113,12 +113,55 @@ let write_config config =
 			(Printexc.to_string e) (Printexc.get_backtrace ());
 		raise Write_error
 
+(* Porting network interaface to ppx: convert ipv4_routes from (string * int * string) list to {gateway:string; netmask:int; subnet:string} *)
+let convert_configuration cfg =
+	let open Yojson.Safe in
+	let convert_ipv4_routes cfg =
+		let convert_ipv4_route cfg =
+			match cfg with
+			| `List [`String gateway; `Int netmask; `String subnet] ->
+				debug "convert ipv4 route";
+				`Assoc ["gateway", `String gateway; "netmask", `Int netmask; "subnet", `String subnet]
+			| other -> other
+		in
+		match cfg with
+		| `List l ->
+			`List (List.map convert_ipv4_route l)
+		| other -> other
+	in
+	let convert_interface_item cfg =
+		match cfg with
+		| `Assoc l ->
+			`Assoc (List.map (fun (k, v) ->
+					let v = if k = "ipv4_routes" then convert_ipv4_routes v else v in
+					k, v
+				) l)
+		| other -> other
+	in
+	let convert_interface_config cfg =
+		match cfg with
+		| `Assoc l ->
+			`Assoc (List.map (fun (k, v) -> k, convert_interface_item v) l)
+		| other -> other
+	in
+	let json = match from_string cfg with
+		| `Assoc l ->
+			`Assoc (List.map (fun (k, v) ->
+					let v = if k = "interface_config" then convert_interface_config v else v in
+					k, v
+				) l)
+		| other -> other
+	in
+	to_string json
+
 let read_config () =
 	try
-		let config_json = Xapi_stdext_unix.Unixext.string_of_file config_file_path in
+		let config_json = Xapi_stdext_unix.Unixext.string_of_file config_file_path |> convert_configuration in
 		match config_json |> Jsonrpc.of_string |> Rpcmarshal.unmarshal typ_of_config_t with
 		| Result.Ok v -> v
-		| Result.Error e -> raise Read_error
+		| Result.Error (`Msg err_msg) ->
+			error "Read configuration error: %s" err_msg;
+			raise Read_error
 	with
 		| Unix.Unix_error (Unix.ENOENT, _, file) ->
 			info "Cannot read networkd configuration file %s because it does not exist." file;

--- a/lib/network_utils.ml
+++ b/lib/network_utils.ml
@@ -18,6 +18,13 @@ open Network_interface
 
 module D = Debug.Make(struct let name = "network_utils" end)
 open D
+exception Script_missing of string
+exception Script_error of (string * string) list
+exception Read_error of string
+exception Write_error of string
+exception Not_implemented
+exception Vlan_in_use of (string * int)
+exception PVS_proxy_connection_error
 
 let iproute2 = "/sbin/ip"
 let resolv_conf = "/etc/resolv.conf"

--- a/networkd/network_monitor.ml
+++ b/networkd/network_monitor.ml
@@ -16,7 +16,7 @@ open Network_interface
 include Network_stats
 
 let write_stats stats =
-	let payload = stats |> rpc_of_stats_t |> Jsonrpc.to_string in
+	let payload = stats |> Rpcmarshal.marshal typ_of_stats_t |> Jsonrpc.to_string in
 	let checksum = payload |> Digest.string |> Digest.to_hex in
 	let length = String.length payload in
 	let data = Printf.sprintf "%s%s%08x%s" magic checksum length payload in

--- a/networkd/network_monitor_thread.ml
+++ b/networkd/network_monitor_thread.ml
@@ -228,8 +228,8 @@ let rec monitor dbg () =
 					dev, stat
 			) devs
 		in
-		
-		let bonds : (string * string list) list = Network_server.Bridge.get_all_bonds () dbg ~from_cache:true () in
+		let from_cache = true in
+		let bonds : (string * string list) list = Network_server.Bridge.get_all_bonds dbg from_cache in
 		let devs =
 			get_link_stats () |>
 			add_bonds bonds |>


### PR DESCRIPTION
1. update implementation per interface changes
1. for interface implementation, move labeled parameter and optional parameter
to positional parameter and remove useless tail unit parameter

Signed-off-by: Yang Qian <yang.qian@citrix.com>

This PR should goes in with https://github.com/xapi-project/xcp-idl/pull/189

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xapi-project/xcp-networkd/128)
<!-- Reviewable:end -->
