### PR TITLE
jbuilder runtest: make it work when _build is not subdir of source root

### DIFF
--- a/test/jbuild
+++ b/test/jbuild
@@ -12,5 +12,5 @@
 
 (alias
  ((name    runtest)
-  (deps    (network_test.exe))
-  (action  (chdir ../../.. (run ${<})))))
+  (deps    (network_test.exe (files_recursively_in jsonrpc_files)))
+  (action  (chdir ../ (run ${<})))))


### PR DESCRIPTION
When you are using jbuilder workspaces the _build dir may not be a subdir of the
source root.
Tell jbuilder to copy the test files from the source dir to the build dir
instead of reading them from the source dir during testing.

Signed-off-by: Edwin Török <edvin.torok@citrix.com>