### PR TITLE
CA-236855: VM.clean_shutdown task not completing on slave

### DIFF
--- a/networkd/network_server.ml
+++ b/networkd/network_server.ml
@@ -1010,45 +1010,53 @@ end
 module S = Network_interface.Interface_API(Idl.GenServerExn ())
 
 module PVS_proxy = struct
-    open S.PVS_proxy
+	open S.PVS_proxy
 
-    let path = ref "/opt/citrix/pvsproxy/socket/pvsproxy"
-    
-    let do_call call =
-            let timebox ~timeout f =
-				let fd_mutex = Xapi_stdext_threads.Threadext.Mutex.create () in
-				let fd_in, fd_out = Unix.pipe () in
-				let fd_closed = ref false in
-				let close_fd fd = Xapi_stdext_threads.Threadext.Mutex.execute fd_mutex
-					( fun () ->
-						if not !fd_closed then begin
-							fd_closed := true;
-							Unix.close fd
-						end
-					)
-				in
-                let _ =  Thread.create
-                    (fun () ->
-                    f ();
-                    debug "Complete execution in thread.";
-                    close_fd fd_out) () in
-                if Thread.wait_timed_read fd_in timeout then
-                    debug "Timed execution completion."
-                else
-                    debug "Timed execution timed out.";
-                Unix.close fd_in;
-                close_fd fd_out
-            in
-            
-            let rpc_call () =
-                try
-                    Jsonrpc_client.with_rpc ~path:!path ~call ()
-                with e ->
-                    error "Error when calling PVS proxy: %s" (Printexc.to_string e);
-                    raise PVS_proxy_connection_error
-            in
+	let path = ref "/opt/citrix/pvsproxy/socket/pvsproxy"
 
-            timebox ~timeout:!pvsproxy_rpc_timeout rpc_call
+	let do_call call =
+		(* To prevent the call stuck due to network or far end reason,
+		 * time box the RPC call by creating another thread to run it.
+		 * Pipe is used to sync the threads, when the working one is finished. *)
+		let timebox ~timeout f =
+			(* Mutex is used to guard the closing of fd_out in case of racing condition 
+			 * between the two threads against double close, whereas some other threads might
+			 * create fd that is just the same (as it is integar). *)
+			let fd_mutex = Xapi_stdext_threads.Threadext.Mutex.create () in
+			let fd_in, fd_out = Unix.pipe () in
+			let fd_closed = ref false in
+			let close_fd fd = Xapi_stdext_threads.Threadext.Mutex.execute fd_mutex
+				( fun () ->
+					if not !fd_closed then begin
+						fd_closed := true;
+						Unix.close fd
+					end
+				)
+			in
+			let _ =  Thread.create
+				(fun () ->
+					f ();
+					debug "Complete execution in thread.";
+					close_fd fd_out) () 
+			in
+			if Thread.wait_timed_read fd_in timeout then
+				debug "Timed execution completion."
+			else
+				debug "Timed execution timed out.";
+			Unix.close fd_in;
+			(* close the fd_out in case the other thread stuck long and causing fd leak *)
+			close_fd fd_out
+		in
+
+		let rpc_call () =
+			try
+				Jsonrpc_client.with_rpc ~path:!path ~call ()
+			with e ->
+				error "Error when calling PVS proxy: %s" (Printexc.to_string e);
+				raise PVS_proxy_connection_error
+		in
+
+		timebox ~timeout:!pvsproxy_rpc_timeout rpc_call
 
 	let configure_site dbg config =
 		debug "Configuring PVS proxy for site %s" config.site_uuid;

--- a/networkd/networkd.ml
+++ b/networkd/networkd.ml
@@ -60,6 +60,8 @@ let options = [
 	"igmp-query-maxresp-time", Arg.Set_string Network_utils.igmp_query_maxresp_time, (fun () -> !Network_utils.igmp_query_maxresp_time), "Maximum Response Time in IGMP Query message to send";
 	"enable-ipv6-mcast-snooping", Arg.Bool (fun x -> Network_utils.enable_ipv6_mcast_snooping := x), (fun () -> string_of_bool !Network_utils.enable_ipv6_mcast_snooping), "IPv6 multicast snooping toggle";
 	"mcast-snooping-disable-flood-unregistered", Arg.Bool (fun x -> Network_utils.mcast_snooping_disable_flood_unregistered := x), (fun () -> string_of_bool !Network_utils.mcast_snooping_disable_flood_unregistered), "Set OVS bridge configuration mcast-snooping-disable-flood-unregistered as 'true' or 'false'";
+    "pvsproxy-rpc-timeout", Arg.Set_float Network_server.pvsproxy_rpc_timeout, (fun () -> string_of_float !Network_server.pvsproxy_rpc_timeout),
+    "Time out value of xcp-networkd to pvsproxy RPC all in float.";
 ]
 
 let start server =


### PR DESCRIPTION
From some historical test, it is found xapi (events_watch thread, for xenopsd events) is stuck some where some time. Further analysis found it is due to some earlier xapi->xcp-networkd call did not get response hence some mutex is not release so later use of the mutex is blocked. The reason the xapi->xcp-networkd is not responsed is further due to xcp-networkd to PVS proxy is not responded. After discussion with Rob and Jon, it is decided to add a time guard for xcp-networkd for the call to PVSproxy.

The implementation added a timebox call, in which another thread is created to do the actual RPC call, and the original thread will wait for some configurable timeout seconds, and proceed if the call did not ended.

Signed-off-by: Yarsin He <yarsin.he@citrix.com>