### PR TITLE
CA-286029: Disabling SR-IOV is failed on sysfs NIC

### DIFF
--- a/lib/network_utils.ml
+++ b/lib/network_utils.ml
@@ -328,7 +328,6 @@ module Sysfs = struct
 
 	let set_sriov_numvfs dev num_vfs =
 		let interface = getpath dev "device/sriov_numvfs" in
-		let oc = open_out interface in
 		try
 			write_one_line interface (string_of_int num_vfs);
 			if get_sriov_numvfs dev = num_vfs then Result.Ok  ()

--- a/networkd/network_server.ml
+++ b/networkd/network_server.ml
@@ -155,7 +155,10 @@ let get_capabilities dev =
 			end
 		| None ->
 			debug "enable SR-IOV on a device: %s via sysfs" dev;
-			(if enable then Sysfs.get_sriov_maxvfs dev else Ok 0) >>= fun numvfs ->
+			begin
+				if enable then Sysfs.get_sriov_maxvfs dev
+				else Sysfs.unbind_child_vfs dev >>= fun () -> Ok 0
+			end >>= fun numvfs ->
 			Sysfs.set_sriov_numvfs dev numvfs >>= fun _ ->
 			Ok Sysfs_successful
 


### PR DESCRIPTION
Before using sysfs interface to config SR-IOV, the function should ensure all VFs are unbound from pciback driver.

Signed-off-by: Wei Xie <wei.xie@citrix.com>