### PR TITLE
CA-236855: VM.clean_shutdown task not completing on slave

### DIFF
--- a/lib/jbuild
+++ b/lib/jbuild
@@ -5,6 +5,8 @@
   (flags (:standard :standard -bin-annot -safe-string))
   (libraries (astring
               forkexec
+              mtime
+              mtime.clock.os
               rpclib
               systemd
               threads

--- a/lib/jsonrpc_client.ml
+++ b/lib/jsonrpc_client.ml
@@ -32,26 +32,29 @@ let timeout_read fd timeout =
 	let read_start = Mtime_clock.counter () in
 	let get_total_used_time () = Mtime.Span.to_uint64_ns (Mtime_clock.count read_start) in
 	let rec inner max_time max_bytes =
-		let (ready_to_read, _, _) = Unix.select [fd] [] [] (to_s max_time) in
+		let (ready_to_read, _, _) = try Unix.select [fd] [] [] (to_s max_time) with
+			(* in case the unix.select call fails in situation like interrupt *)
+			| _ -> [], [], []
+		in
 		(* This is not accurate the calculate time just for the select part. However, we
 		 * think the read time will be minor comparing to the scale of tens of seconds.
 		 * the current style will be much concise in code. *)
-		let used_time = get_total_used_time () in
-		let remain_time = Int64.sub timeout used_time in
+		let remain_time = 
+			let used_time = get_total_used_time () in
+			Int64.sub timeout used_time
+		in
 		if remain_time < 0L then 
 		begin
 			debug "Timeout after read %d" (Buffer.length buf);
 			raise Timeout
 		end;
-		if List.mem fd ready_to_read
-		then
+		if List.mem fd ready_to_read then
 		begin
 			let bytes = Bytes.make 4096 '\000' in
 			match Unix.read fd bytes 0 4096 with
 				| 0 -> Buffer.contents buf (* EOF *)
 				| n ->
-					if n > max_bytes
-					then
+					if n > max_bytes then
 					begin
 						debug "exceeding maximum read limit %d, clear buffer" !json_rpc_max_len;
 						Buffer.clear buf;
@@ -75,30 +78,35 @@ let timeout_read fd timeout =
 let timeout_write filedesc total_length data response_time =
 	let write_start = Mtime_clock.counter () in
 	let get_total_used_time () = Mtime.Span.to_uint64_ns (Mtime_clock.count write_start) in
-	let rec inner_write filedesc offset length remain_time =
-		let (_, ready_to_write, _) = Unix.select [] [filedesc] [] (to_s remain_time) in 
-		let used_time = get_total_used_time () in
-		let new_remain_time = Int64.sub response_time used_time in
-		if new_remain_time < 0L then
+	let rec inner_write offset max_time =
+		let (_, ready_to_write, _) = try Unix.select [] [filedesc] [] (to_s max_time) with
+			(* in case the unix.select call fails in situation like interrupt *)
+			| _ -> [], [], []
+		in
+		let remain_time = 
+			let used_time = get_total_used_time () in
+			Int64.sub response_time used_time
+		in
+		if remain_time < 0L then
 		begin
 			debug "Timeout to write %d at offset %d" total_length offset;
 			raise Timeout
 		end;
 		if List.mem filedesc ready_to_write then 
 		begin
+			let length = total_length - offset in
 			let bytes_written = 
 				(try Unix.single_write filedesc data offset length with 
 				| Unix.Unix_error(Unix.EAGAIN,_,_)
 				| Unix.Unix_error(Unix.EWOULDBLOCK,_,_) -> 0)
 			in
 			let new_offset = offset + bytes_written in
-			let new_length = length - bytes_written in
-			if new_length = 0 then ()
-			else inner_write filedesc new_offset new_length new_remain_time
+			if length = bytes_written then ()
+			else inner_write new_offset remain_time
 		end
-		else inner_write filedesc offset length new_remain_time
+		else inner_write offset remain_time
 	in
-	inner_write filedesc 0 total_length response_time
+	inner_write 0 response_time
 
 let with_rpc ?(version=Jsonrpc.V2) ~path ~call () =
 	let uri = Uri.of_string (Printf.sprintf "file://%s" path) in

--- a/lib/jsonrpc_client.ml
+++ b/lib/jsonrpc_client.ml
@@ -17,49 +17,95 @@
 module D = Debug.Make(struct let name = "jsonrpc_client" end)
 open D
 
-let input_json_object fin =
-	let buf = Buffer.create 1024 in
-	let brace_cnt = ref 0 in
-	let in_string = ref false in
-	let last_char () = Buffer.nth buf (Buffer.length buf - 1) in
-	let rec get () =
-		let c = input_char fin in
+exception Timeout
+exception Read_error
+
+let json_rpc_max_len = ref 65536 (* Arbitrary maximum length of RPC response *)
+let json_rpc_read_timeout = ref "60000000000"
+let json_rpc_write_timeout = ref "60000000000"
+
+let to_s  s = (Int64.to_float s) *. 1e-9
+
+(* Read the entire contents of the fd, of unknown length *)
+let timeout_read fd timeout =
+	let buf = Buffer.create !json_rpc_max_len in
+	let read_start = Mtime_clock.counter () in
+	let get_total_used_time () = Mtime.Span.to_uint64_ns (Mtime_clock.count read_start) in
+	let rec inner max_time max_bytes =
+		let (ready_to_read, _, _) = Unix.select [fd] [] [] (to_s max_time) in
+		(* This is not accurate the calculate time just for the select part. However, we
+		 * think the read time will be minor comparing to the scale of tens of seconds.
+		 * the current style will be much concise in code. *)
+		let used_time = get_total_used_time () in
+		let remain_time = Int64.sub timeout used_time in
+		if remain_time < 0L then 
 		begin
-			match c with
-			| '{' when not !in_string -> brace_cnt := !brace_cnt + 1
-			| '}' when not !in_string -> brace_cnt := !brace_cnt - 1
-			| '"' when !in_string && (last_char () <> '\\') -> in_string := false
-			| '"' when not !in_string -> in_string := true
-			| _ -> ()
+			debug "Timeout after read %d" (Buffer.length buf);
+			raise Timeout
 		end;
-		Buffer.add_char buf c;
-		if !brace_cnt > 0 then
-			get ()
+		if List.mem fd ready_to_read
+		then
+		begin
+			let bytes = Bytes.make 4096 '\000' in
+			match Unix.read fd bytes 0 4096 with
+				| 0 -> Buffer.contents buf (* EOF *)
+				| n ->
+					if n > max_bytes
+					then
+					begin
+						debug "exceeding maximum read limit %d, clear buffer" !json_rpc_max_len;
+						Buffer.clear buf;
+						raise Read_error
+					end
+					else
+					begin
+						Buffer.add_subbytes buf bytes 0 n;
+						inner remain_time (max_bytes - n)
+					end
+				| exception Unix.Unix_error(err,_,_) when err = Unix.EAGAIN || err = Unix.EWOULDBLOCK ->
+					inner remain_time max_bytes
+		end
+		else inner remain_time max_bytes
 	in
-	get ();
-	Buffer.contents buf
+	inner timeout !json_rpc_max_len
 
-let receive fin =
-	let obj = input_json_object fin in
-	debug "Response: %s" obj;
-	Jsonrpc.response_of_string obj
-
-let with_connection sockaddr f =
-	let fin, fout = Unix.open_connection sockaddr in
-	debug "Connected.";
-	let result = f fin fout in
-	Unix.shutdown_connection fin;
-	close_in fin;
-	debug "Shut down.";
-	result
+(* Write as many bytes to a file descriptor as possible from data before a given clock time. *)
+(* Raises Timeout exception if the number of bytes written is less than the specified length. *)
+(* Writes into the file descriptor at the current cursor position. *)
+let timeout_write filedesc total_length data response_time =
+	let write_start = Mtime_clock.counter () in
+	let get_total_used_time () = Mtime.Span.to_uint64_ns (Mtime_clock.count write_start) in
+	let rec inner_write filedesc offset length remain_time =
+		let (_, ready_to_write, _) = Unix.select [] [filedesc] [] (to_s remain_time) in 
+		let used_time = get_total_used_time () in
+		let new_remain_time = Int64.sub response_time used_time in
+		if new_remain_time < 0L then
+		begin
+			debug "Timeout to write %d at offset %d" total_length offset;
+			raise Timeout
+		end;
+		if List.mem filedesc ready_to_write then 
+		begin
+			let bytes_written = 
+				(try Unix.single_write filedesc data offset length with 
+				| Unix.Unix_error(Unix.EAGAIN,_,_)
+				| Unix.Unix_error(Unix.EWOULDBLOCK,_,_) -> 0)
+			in
+			let new_offset = offset + bytes_written in
+			let new_length = length - bytes_written in
+			if new_length = 0 then ()
+			else inner_write filedesc new_offset new_length new_remain_time
+		end
+		else inner_write filedesc offset length new_remain_time
+	in
+	inner_write filedesc 0 total_length response_time
 
 let with_rpc ?(version=Jsonrpc.V2) ~path ~call () =
-	let sockaddr = Unix.ADDR_UNIX path in
-	with_connection sockaddr (fun fin fout ->
-		let req = Jsonrpc.string_of_call ~version call in
-		debug "Request: %s" req;
-		output_string fout req;
-		flush fout;
-		receive fin
-	)
-
+	let uri = Uri.of_string (Printf.sprintf "file://%s" path) in
+	Open_uri.with_open_uri uri (fun s ->
+		Unix.set_nonblock s;
+		let req = Bytes.of_string (Jsonrpc.string_of_call ~version call) in
+		timeout_write s (Bytes.length req) req (Int64.of_string !json_rpc_write_timeout);
+		let res = timeout_read s (Int64.of_string !json_rpc_read_timeout) in
+		debug "Response: %s" res;
+		Jsonrpc.response_of_string res)

--- a/lib/jsonrpc_client.mli
+++ b/lib/jsonrpc_client.mli
@@ -12,9 +12,12 @@
  * GNU Lesser General Public License for more details.
  *)
 
+val json_rpc_max_len : int ref
+val json_rpc_read_timeout : string ref
+val json_rpc_write_timeout : string ref
+
+val timeout_read : Unix.file_descr -> int64 -> string
 (** Do an JSON-RPC call to a server that is listening on a Unix domain 
  *  socket at the given path. *)
 val with_rpc : ?version:Jsonrpc.version -> path:string -> call:Rpc.call -> unit -> Rpc.response
 
-(** Read an entire JSON object from an input channel. *)
-val input_json_object : in_channel -> string

--- a/lib/jsonrpc_client.mli
+++ b/lib/jsonrpc_client.mli
@@ -12,6 +12,9 @@
  * GNU Lesser General Public License for more details.
  *)
 
+exception Timeout
+exception Read_error
+
 val json_rpc_max_len : int ref
 val json_rpc_read_timeout : string ref
 val json_rpc_write_timeout : string ref

--- a/lib/jsonrpc_client.mli
+++ b/lib/jsonrpc_client.mli
@@ -16,8 +16,8 @@ exception Timeout
 exception Read_error
 
 val json_rpc_max_len : int ref
-val json_rpc_read_timeout : string ref
-val json_rpc_write_timeout : string ref
+val json_rpc_read_timeout : int64 ref
+val json_rpc_write_timeout : int64 ref
 
 val timeout_read : Unix.file_descr -> int64 -> string
 (** Do an JSON-RPC call to a server that is listening on a Unix domain 

--- a/networkd/networkd.ml
+++ b/networkd/networkd.ml
@@ -64,6 +64,9 @@ let options = [
 	"dracut-cmd-path", Arg.Set_string Network_utils.dracut, (fun () -> !Network_utils.dracut), "Path to the Unix command dracut";
 	"dracut-timeout", Arg.Set_float Network_utils.dracut_timeout, (fun () -> string_of_float !Network_utils.dracut_timeout), "Default value for the dracut command timeout";
 	"modinfo-cmd-path", Arg.Set_string Network_utils.modinfo, (fun () -> !Network_utils.modinfo), "Path to the Unix command modinfo";
+	"json-rpc-max-len", Arg.Set_int Jsonrpc_client.json_rpc_max_len, (fun () -> string_of_int !Jsonrpc_client.json_rpc_max_len), "Maximum buffer size for Json RPC response";
+	"json-rpc-read-timeout", Arg.Set_string Jsonrpc_client.json_rpc_read_timeout, (fun () -> !Jsonrpc_client.json_rpc_read_timeout), "JSON RPC response read timeout value in ns";
+	"json-rpc-write-timeout", Arg.Set_string Jsonrpc_client.json_rpc_write_timeout, (fun () -> !Jsonrpc_client.json_rpc_write_timeout), "JSON RPC write timeout value in ns";
 ]
 
 let start server =

--- a/networkd/networkd.ml
+++ b/networkd/networkd.ml
@@ -65,8 +65,8 @@ let options = [
 	"dracut-timeout", Arg.Set_float Network_utils.dracut_timeout, (fun () -> string_of_float !Network_utils.dracut_timeout), "Default value for the dracut command timeout";
 	"modinfo-cmd-path", Arg.Set_string Network_utils.modinfo, (fun () -> !Network_utils.modinfo), "Path to the Unix command modinfo";
 	"json-rpc-max-len", Arg.Set_int Jsonrpc_client.json_rpc_max_len, (fun () -> string_of_int !Jsonrpc_client.json_rpc_max_len), "Maximum buffer size for Json RPC response";
-	"json-rpc-read-timeout", Arg.Set_string Jsonrpc_client.json_rpc_read_timeout, (fun () -> !Jsonrpc_client.json_rpc_read_timeout), "JSON RPC response read timeout value in ns";
-	"json-rpc-write-timeout", Arg.Set_string Jsonrpc_client.json_rpc_write_timeout, (fun () -> !Jsonrpc_client.json_rpc_write_timeout), "JSON RPC write timeout value in ns";
+	"json-rpc-read-timeout", Arg.Int (fun x -> Jsonrpc_client.json_rpc_read_timeout := Int64.(mul 1000L (of_int x))), (fun () -> Int64.(to_string (div !Jsonrpc_client.json_rpc_read_timeout 1000L))), "JSON RPC response read timeout value in ms";
+	"json-rpc-write-timeout", Arg.Int (fun x -> Jsonrpc_client.json_rpc_write_timeout := Int64.(mul 1000L (of_int x))), (fun () -> Int64.(to_string (div !Jsonrpc_client.json_rpc_write_timeout 1000L))), "JSON RPC write timeout value in ms";
 ]
 
 let start server =

--- a/networkd/networkd.ml
+++ b/networkd/networkd.ml
@@ -65,8 +65,8 @@ let options = [
 	"dracut-timeout", Arg.Set_float Network_utils.dracut_timeout, (fun () -> string_of_float !Network_utils.dracut_timeout), "Default value for the dracut command timeout";
 	"modinfo-cmd-path", Arg.Set_string Network_utils.modinfo, (fun () -> !Network_utils.modinfo), "Path to the Unix command modinfo";
 	"json-rpc-max-len", Arg.Set_int Jsonrpc_client.json_rpc_max_len, (fun () -> string_of_int !Jsonrpc_client.json_rpc_max_len), "Maximum buffer size for Json RPC response";
-	"json-rpc-read-timeout", Arg.Int (fun x -> Jsonrpc_client.json_rpc_read_timeout := Int64.(mul 1000L (of_int x))), (fun () -> Int64.(to_string (div !Jsonrpc_client.json_rpc_read_timeout 1000L))), "JSON RPC response read timeout value in ms";
-	"json-rpc-write-timeout", Arg.Int (fun x -> Jsonrpc_client.json_rpc_write_timeout := Int64.(mul 1000L (of_int x))), (fun () -> Int64.(to_string (div !Jsonrpc_client.json_rpc_write_timeout 1000L))), "JSON RPC write timeout value in ms";
+	"json-rpc-read-timeout", Arg.Int (fun x -> Jsonrpc_client.json_rpc_read_timeout := Int64.(mul 1000000L (of_int x))), (fun () -> Int64.(to_string (div !Jsonrpc_client.json_rpc_read_timeout 1000000L))), "JSON RPC response read timeout value in ms";
+	"json-rpc-write-timeout", Arg.Int (fun x -> Jsonrpc_client.json_rpc_write_timeout := Int64.(mul 1000000L (of_int x))), (fun () -> Int64.(to_string (div !Jsonrpc_client.json_rpc_write_timeout 1000000L))), "JSON RPC write timeout value in ms";
 ]
 
 let start server =

--- a/test/test_jsonrpc_client.ml
+++ b/test/test_jsonrpc_client.ml
@@ -41,7 +41,7 @@ module Input_json_object = Generic.Make (struct
 		let fin = open_in (Filename.concat dir filename) in
 		let response =
 			try
-				let json = Jsonrpc_client.input_json_object fin in
+				let json = Jsonrpc_client.timeout_read (Unix.descr_of_in_channel fin) 5_000_000_000L in
 				let rpc = Jsonrpc.of_string json in
 				Right rpc
 			with
@@ -57,11 +57,8 @@ module Input_json_object = Generic.Make (struct
 		"good_call.json", Right good_call;
 
 		(* A file containing a partial JSON object. *)
-		"short_call.json", Left End_of_file;
+		"short_call.json", Left Parse_error;
 
-		(* A file containing a JSON object, plus some more characters at the end. *)
-		"good_call_plus.json", Right good_call;
-		
 		(* A file containing some invalid JSON object. *)
 		"bad_call.json", (Left Parse_error);
 	]

--- a/xapi-networkd.opam
+++ b/xapi-networkd.opam
@@ -10,6 +10,7 @@ build-test: ["jbuilder" "runtest" "-p" name]
 depends: [
   "jbuilder" {build}
   "astring"
+  "mtime"
   "netlink"
   "rpc"
   "systemd"


### PR DESCRIPTION
* CA-236855: VM.clean_shutdown task not completing on slave

According to the discussion (also recorded in the ticket), this change
will use the newly created read_timeout and write_timeout to process
input and output from outside. Some updates according to Nanjing peer review.

Modified test case to remove the cases that is not applied.

Signed-off-by: YarsinCitrix <yarsin.he@citrix.com>