### PR TITLE
CA-291495: Fall back to Ip.link_set_mtu if OVS.set_mtu fails

### DIFF
--- a/networkd/network_server.ml
+++ b/networkd/network_server.ml
@@ -443,7 +443,11 @@ module Interface = struct
 			debug "Configuring MTU for %s: %d" name mtu;
 			update_config name {(get_config name) with mtu};
 			match !backend_kind with
-			| Openvswitch -> ignore (Ovs.set_mtu name mtu)
+			| Openvswitch ->
+				(try
+					ignore (Ovs.set_mtu name mtu)
+				with _ ->
+					Ip.link_set_mtu name mtu)
 			| Bridge -> Ip.link_set_mtu name mtu
 		) ()
 


### PR DESCRIPTION
OVS.set_mtu is a new function (since ed2151f8), which requires a newer version
of the OVS that supports the mtu_request feature. If the installed OVS does not
have this feature, then the function will raise an exception. For compatibility
reasons, we now catch this exception and fall back to Ip.link_set_mtu.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>