### PR TITLE
CA-291197: Toolstack no longer ignores junk at the end of JSON-RPC re…

### DIFF
--- a/lib/jsonrpc_client.mli
+++ b/lib/jsonrpc_client.mli
@@ -19,6 +19,8 @@ val json_rpc_max_len : int ref
 val json_rpc_read_timeout : int64 ref
 val json_rpc_write_timeout : int64 ref
 
+val retrieve_json_str : string -> string
+
 val timeout_read : Unix.file_descr -> int64 -> string
 (** Do an JSON-RPC call to a server that is listening on a Unix domain 
  *  socket at the given path. *)

--- a/test/test_jsonrpc_client.ml
+++ b/test/test_jsonrpc_client.ml
@@ -41,7 +41,8 @@ module Input_json_object = Generic.Make (struct
 		let fin = open_in (Filename.concat dir filename) in
 		let response =
 			try
-				let json = Jsonrpc_client.timeout_read (Unix.descr_of_in_channel fin) 5_000_000_000L in
+				let buff = Jsonrpc_client.timeout_read (Unix.descr_of_in_channel fin) 5_000_000_000L in
+				let json = Jsonrpc_client.retrieve_json_str buff in
 				let rpc = Jsonrpc.of_string json in
 				Right rpc
 			with
@@ -55,6 +56,9 @@ module Input_json_object = Generic.Make (struct
 		(* A file containing exactly one JSON object. *)
 		(* It has got curly braces inside strings to make it interesting. *)
 		"good_call.json", Right good_call;
+
+		(* A file containing a JSON object, plus some more characters at the end. *)
+		"good_call_plus.json", Right good_call;
 
 		(* A file containing a partial JSON object. *)
 		"short_call.json", Left Parse_error;


### PR DESCRIPTION
…sponses from pvsproxy

This is resulted by CA-236855, in that the read strategy is changed to assume all good
data will come from PVSproxy side. However, in testing, it is found a bug in PVSproxy,
which was not fatal locally, but resulted issue in overall scenario. It is decided to
enhance the solution a little bit based on previous change.

The updates as to integrate some part in the old byte by byte read, where a function
is used to prescreen the data read from PVSproxy, and tailing junk is discarded, so
the only json part is further processed. Here we most copied the original function,
but added:
 1. to get input chars from a string;
 2. to tolerant heading spaces/junk (in screening);

Signed-off-by: YarsinCitrix <yarsin.he@citrix.com>