### PR TITLE
CA-291197: Toolstack no longer ignores junk at the end of JSON-RPC re…

### DIFF
--- a/lib/jsonrpc_client.ml
+++ b/lib/jsonrpc_client.ml
@@ -115,4 +115,4 @@ let with_rpc ?(version=Jsonrpc.V2) ~path ~call () =
 		timeout_write s (Bytes.length req) req !json_rpc_write_timeout;
 		let res = timeout_read s !json_rpc_read_timeout in
 		debug "Response: %s" res;
-		Jsonrpc.response_of_string res)
+		Jsonrpc.response_of_string ~strict:false res)

--- a/test/test_jsonrpc_client.ml
+++ b/test/test_jsonrpc_client.ml
@@ -42,7 +42,7 @@ module Input_json_object = Generic.Make (struct
 		let response =
 			try
 				let json = Jsonrpc_client.timeout_read (Unix.descr_of_in_channel fin) 5_000_000_000L in
-				let rpc = Jsonrpc.of_string json in
+				let rpc = Jsonrpc.of_string ~strict:false json in
 				Right rpc
 			with
 			| End_of_file -> Left End_of_file
@@ -58,6 +58,9 @@ module Input_json_object = Generic.Make (struct
 
 		(* A file containing a partial JSON object. *)
 		"short_call.json", Left Parse_error;
+
+		(* A file containing a JSON object, plus some more characters at the end. *)
+		"good_call_plus.json", Right good_call;
 
 		(* A file containing some invalid JSON object. *)
 		"bad_call.json", (Left Parse_error);


### PR DESCRIPTION
…sponse

The previous changes for CA-236855 no longer tolerant junk at the end of
input from the pvsproxy, which makes the interface more fragile. To build
a more robust interface in case of issue on the pvsproxy side, new option
strict from jsonrpc is used to interpret the response, so tailing junk
is ignored.

Signed-off-by: YarsinCitrix <yarsin.he@citrix.com>