### PR TITLE
network_monitor_thread: use Xmlrpc_client instead of Rpc_client

### DIFF
--- a/networkd/jbuild
+++ b/networkd/jbuild
@@ -22,7 +22,6 @@
               networklibs
               profiling
               rpclib
-              rpclib.unix
               systemd
               threads
               xapi-stdext-monadic

--- a/networkd/network_monitor_thread.ml
+++ b/networkd/network_monitor_thread.ml
@@ -28,11 +28,9 @@ let monitor_whitelist = ref [
 	"vif"; (* This includes "tap" owing to the use of standardise_name below *)
 ]
 
-let xapi_rpc request =
-	Rpc_client.do_rpc_unix
-		~content_type:(Rpc_client.content_type_of_string "text/xml")
-		~filename:(Filename.concat "/var/lib/xcp" "xapi")
-		~path:"/" request
+let xapi_rpc xml =
+  let open Xmlrpc_client in
+  XMLRPC_protocol.rpc ~srcstr:"xcp-networkd" ~dststr:"xapi" ~transport:(Unix "/var/xapi/xapi") ~http:(xmlrpc ~version:"1.0" "/") xml
 
 let send_bond_change_alert dev interfaces message =
 	let ifaces = String.concat "+" (List.sort String.compare interfaces) in


### PR DESCRIPTION
For compatibility with new rpclib 5.8.0, see failure in https://github.com/xapi-project/xs-opam/pull/291 -
the Rpc_client module has been removed from ocaml-rpc