### PR TITLE
CA-310516: Detect vlan created on first boot as managed

### DIFF
--- a/lib/network_config.ml
+++ b/lib/network_config.ml
@@ -23,6 +23,8 @@ exception Write_error
 let empty_config = default_config
 
 let config_file_path = "/var/lib/xcp/networkd.db"
+let temp_vlan = "xentemp"
+
 
 let bridge_naming_convention (device: string) =
   if Astring.String.is_prefix ~affix:"eth" device
@@ -56,7 +58,7 @@ let read_management_conf () =
             (* At this point, we don't know what the VLAN bridge name will be,
              * so use a temporary name. Xapi will replace the bridge once the name
              * has been decided on. *)
-            "xentemp"
+            temp_vlan
         in
         debug "No management bridge in inventory file... using %s" bridge;
         bridge

--- a/networkd/network_server.ml
+++ b/networkd/network_server.ml
@@ -486,7 +486,7 @@ module Interface = struct
   let has_vlan dbg name vlan =
     (* Identify the vlan is used by kernel which is unknown to XAPI *)
     Debug.with_thread_associated dbg (fun () ->
-        let temp_interfaces = Sysfs.bridge_to_interfaces "xentemp" in
+        let temp_interfaces = Sysfs.bridge_to_interfaces Network_config.temp_vlan in
         List.exists (fun (d, v, p) -> v = vlan && p = name && not (List.mem d temp_interfaces)) (Proc.get_vlans ())
       ) ()
 

--- a/networkd/network_server.ml
+++ b/networkd/network_server.ml
@@ -174,7 +174,7 @@ module Sriov = struct
       ) ()
 
   let disable dbg name =
-    Debug.with_thread_associated dbg (fun () ->	
+    Debug.with_thread_associated dbg (fun () ->
         debug "Disable network SR-IOV by name: %s" name;
         match config_sriov ~enable:false name with
         | Ok _ -> (Ok:disable_result)
@@ -200,7 +200,7 @@ module Sriov = struct
       (fun () -> Ip.set_vf_rate dev index 0) rate
 
   let make_vf_config dbg pci_address (vf_info : sriov_pci_t) =
-    Debug.with_thread_associated dbg (fun () ->	
+    Debug.with_thread_associated dbg (fun () ->
         let vlan = Opt.map Int64.to_int vf_info.vlan
         and rate = Opt.map Int64.to_int vf_info.rate
         and pcibuspath = Xcp_pci.string_of_address pci_address in

--- a/networkd/network_server.ml
+++ b/networkd/network_server.ml
@@ -486,7 +486,8 @@ module Interface = struct
   let has_vlan dbg name vlan =
     (* Identify the vlan is used by kernel which is unknown to XAPI *)
     Debug.with_thread_associated dbg (fun () ->
-        List.exists (fun (_, v, p) -> v = vlan && p = name) (Proc.get_vlans ())
+        let temp_interfaces = Sysfs.bridge_to_interfaces "xentemp" in
+        List.exists (fun (d, v, p) -> v = vlan && p = name && not (List.mem d temp_interfaces)) (Proc.get_vlans ())
       ) ()
 
   let bring_up _ dbg ~name =


### PR DESCRIPTION
On first boot networkd may create a vlan named xentemp and the firstboot script call xapi to create that same vlan to get recognized by xapi.
networkd need to recognise this case, otherwise an error occurs and the setup fails.