### PR TITLE
CA-310413: Unconditionally apply enic workaround (again)

### DIFF
--- a/lib/network_utils.ml
+++ b/lib/network_utils.ml
@@ -123,13 +123,6 @@ module Sysfs = struct
       warn "Failed to obtain list of drivers from sysfs";
       []
 
-  let get_driver_version driver () =
-    try
-      Some (String.trim (Xapi_stdext_unix.Unixext.string_of_file ("/sys/bus/pci/drivers/" ^ driver ^ "/module/version")))
-    with _ ->
-      warn "Failed to obtain driver version from sysfs";
-      None
-
   let getpath dev attr =
     Printf.sprintf "/sys/class/net/%s/%s" dev attr
 

--- a/networkd/networkd.ml
+++ b/networkd/networkd.ml
@@ -50,7 +50,6 @@ let resources = [
 let options = [
   "monitor_whitelist", Arg.String (fun x -> Network_monitor_thread.monitor_whitelist := Astring.String.cuts ~empty:false ~sep:"," x), (fun () -> String.concat "," !Network_monitor_thread.monitor_whitelist), "List of prefixes of interface names that are to be monitored";
   "mac-table-size", Arg.Set_int Network_utils.mac_table_size, (fun () -> string_of_int !Network_utils.mac_table_size), "Default value for the mac-table-size openvswitch parameter (see ovs-vswitchd.conf.db.5)";
-  "enic-workaround-until-version", Arg.Set_string Network_server.enic_workaround_until_version, (fun () -> !Network_server.enic_workaround_until_version), "The version till enic driver workaround will be applied or the version set to an empty string for not applying the workaround.";
   "pvs-proxy-socket", Arg.Set_string Network_server.PVS_proxy.path, (fun () -> !Network_server.PVS_proxy.path), "Path to the Unix domain socket for the PVS-proxy daemon";
   "igmp-query-maxresp-time", Arg.Set_string Network_utils.igmp_query_maxresp_time, (fun () -> !Network_utils.igmp_query_maxresp_time), "Maximum Response Time in IGMP Query message to send";
   "enable-ipv6-mcast-snooping", Arg.Bool (fun x -> Network_utils.enable_ipv6_mcast_snooping := x), (fun () -> string_of_bool !Network_utils.enable_ipv6_mcast_snooping), "IPv6 multicast snooping toggle";


### PR DESCRIPTION
This reverts 9d5309e8018664ed2766e52aeeb1f39d26c5a88d. The reason is that the
workaround is once again needed on the current version of the enic driver.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>