### PR TITLE
Enable IPv6 on interfaces when enabled globally and configured

### DIFF
--- a/networkd/network_server.ml
+++ b/networkd/network_server.ml
@@ -533,10 +533,14 @@ module Interface = struct
                                      ethtool_settings; ethtool_offload; _} as c)) ->
             update_config name c;
             exec (fun () ->
-                (* We only apply the DNS settings when in static IPv4 mode to avoid conflicts with DHCP mode.
+                (* We only apply the DNS settings when not in a DHCP mode to avoid conflicts.
                    					 * The `dns` field should really be an option type so that we don't have to derive the intention
                    					 * of the caller by looking at other fields. *)
-                match ipv4_conf with Static4 _ -> set_dns () dbg ~name ~nameservers ~domains | _ -> ());
+                match (ipv4_conf, ipv6_conf) with
+                  | (Static4 _, _)
+                  | (_, Static6 _)
+                  | (_, Autoconf6) -> set_dns () dbg ~name ~nameservers ~domains
+                  | _ -> ());
             exec (fun () -> set_ipv4_conf dbg name ipv4_conf);
             exec (fun () -> match ipv4_gateway with None -> () | Some gateway ->
                 set_ipv4_gateway () dbg ~name ~address:gateway);

--- a/networkd/network_server.ml
+++ b/networkd/network_server.ml
@@ -355,15 +355,15 @@ module Interface = struct
             ignore (Dhclient.stop ~ipv6:true name);
           Sysctl.set_ipv6_autoconf name false;
           (* add the link_local and clean the old one only when needed *)
-          let cur_addrs =
-            let addrs = Ip.get_ipv6 name in
+          let cur_addrs = Ip.get_ipv6 name in
+          let target_addrs =
             let maybe_link_local = Ip.split_addr (Ip.get_ipv6_link_local_addr name) in
             match maybe_link_local with
             | Some addr -> Xapi_stdext_std.Listext.List.setify (addr :: addrs)
             | None -> addrs
           in
-          let rm_addrs = Xapi_stdext_std.Listext.List.set_difference cur_addrs addrs in
-          let add_addrs = Xapi_stdext_std.Listext.List.set_difference addrs cur_addrs in
+          let rm_addrs = Xapi_stdext_std.Listext.List.set_difference cur_addrs target_addrs in
+          let add_addrs = Xapi_stdext_std.Listext.List.set_difference target_addrs cur_addrs in
           List.iter (Ip.del_ip_addr name) rm_addrs;
           List.iter (Ip.set_ip_addr name) add_addrs
       end


### PR DESCRIPTION
By default XenServer disables IPv6 globally in `/etc/sysconfig/network` and via the sysctl `net.ipv6.conf.{default,all}.disable_ipv6=1`.  `xe-enable-ipv6` changes `/etc/sysconfig/network` but leaves the sysctl alone, for good reason since enabling IPv6 on every interface would cause dom0 to configure link-local addresses on every bridge.  Currently, xcp-networkd refuses to configure IPv6 on an interface when sysctl `net.ipv6.conf.all.disable_ipv6` is set.

Instead, distinguish between the two and have xcp-networkd enable IPv6 on an interface when `xe-enable-ipv6` has been used and an IPv6 configuration mode has been set on that interface.

This has no effect by default on XenServer, unless the user has run `xe-enable-ipv6` or otherwise manually enabled it system-wide (or where `/etc/sysconfig/network` doesn't exist).

Also, correct a couple of cases where IPv6 users might end up with no DNS or no link-local address.