### PR TITLE
CA-320563: xcp-networkd: fix the regex match for PCI BDF string

### DIFF
--- a/lib/network_utils.ml
+++ b/lib/network_utils.ml
@@ -246,7 +246,7 @@ module Sysfs = struct
     try
       Sys.readdir ("/sys/bus/pci/drivers/" ^ driver)
       |> Array.to_list
-      |> List.filter (Re.execp (Re.Perl.compile_pat "\\d+:\\d+:\\d+\\.\\d+"))
+      |> List.filter (Re.execp (Re.Perl.compile_pat "\\d+:[a-f\\d]+:[a-f\\d]+\\.\\d+"))
       |> List.length
     with _ -> 0
 


### PR DESCRIPTION
PCI BDF format: up to 256 buses, each with up to 32 devices, each
supporting eight functions.

This commit fixes the regex match to include hex strings.