### PR TITLE
CA-324959: suppport both DNS= and DNS%d= formats

### DIFF
--- a/lib/network_config.ml
+++ b/lib/network_config.ml
@@ -48,10 +48,17 @@ let read_management_conf () =
 					else None
 				in
 				let nameservers =
-					if List.mem_assoc "DNS" args && List.assoc "DNS" args <> "" then
-						List.map Unix.inet_addr_of_string (String.split ',' (List.assoc "DNS" args))
+					if List.mem_assoc "DNS1" args && List.assoc "DNS1" args <> "" then
+						args |> List.fold_left (fun accum (k, v) ->
+							try Scanf.sscanf k "DNS%d" (fun i -> (i, String.split ',' v) :: accum)
+							with _ -> accum) []
+						|> List.sort (fun (k1, _) (k2, _) -> k1-k2)
+						|> List.map snd |> List.concat
+					else if List.mem_assoc "DNS" args && List.assoc "DNS" args <> "" then
+						String.split ',' (List.assoc "DNS" args)
 					else []
 				in
+				let nameservers = List.map Unix.inet_addr_of_string nameservers in
 				let domains =
 					if List.mem_assoc "DOMAIN" args && List.assoc "DOMAIN" args <> "" then
 						String.split ' ' (List.assoc "DOMAIN" args)


### PR DESCRIPTION
DNS%d= is written by host-installer,
and DNS= would've been written by the non-hotfixed version of XAPI on
pool eject/network reset.
DNS1 could contain comma-separated values too, handle this by splitting each
value and then List.concat at the end.

See https://github.com/xapi-project/xen-api/pull/3931 why this is needed