### PR TITLE
CA-324959: do not loose DNS settings after a network reset

### DIFF
--- a/lib/network_config.ml
+++ b/lib/network_config.ml
@@ -70,7 +70,7 @@ let read_management_conf () =
 				DHCP4, None, ([], [])
 		in
 		let phy_interface = {default_interface with persistent_i = true} in
-		let bridge_interface = {default_interface with ipv4_conf; ipv4_gateway; persistent_i = true} in
+		let bridge_interface = {default_interface with ipv4_conf; ipv4_gateway; persistent_i = true; dns} in
 		let bridge = {default_bridge with
 			bridge_mac = Some mac;
 			ports = [device, {default_port with interfaces = [device]}];


### PR DESCRIPTION
This results in an empty /etc/resolv.conf when using static IPs:
```
systemctl stop xcp-networkd
rm /var/lib/xcp/networkd.db
systemctl start xcp-networkd
```

After the fix we get a working /etc/resolv.conf.
This affects master too.

