### PR TITLE
allow use of already enabled sr-iov virtual functions in xapi managed sr-iov networks

### DIFF
--- a/networkd/network_server.ml
+++ b/networkd/network_server.ml
@@ -130,19 +130,31 @@ module Sriov = struct
       else
         Ok Modprobe_successful_requires_reboot
     | None ->
-      debug "%s SR-IOV on a device: %s via sysfs" op dev;
+      (* enable: try sysfs interface to set numfvs = maxvfs. if fails, but vfs are enabled, assume manual configuration.
+         disable: Net.Sriov.disable will not be called for manually configured interfaces, as determined by `require_operation_on_pci_device` *)
+      let man_successful () =
+        debug "SR-IOV/VFs %sd manually on device: %s" op dev;
+        Manual_successful
+      in
+      if enable then
       begin
-        if enable then Sysfs.get_sriov_maxvfs dev
-        else Sysfs.unbind_child_vfs dev >>= fun () -> Ok 0
-      end >>= fun numvfs ->
-      let sysfs_numvfs = Sysfs.get_sriov_numvfs dev in
-      (if sysfs_numvfs <> 0 then
-      begin
-        debug "%d vfs already enabled on device: %s" sysfs_numvfs dev;
-        Ok ()
+        let present_numvfs = Sysfs.get_sriov_numvfs dev in
+        match Sysfs.get_sriov_maxvfs dev >>= fun maxvfs -> maxvfs |> Sysfs.set_sriov_numvfs dev
+        with
+        | Ok _ -> debug "%s SR-IOV on a device: %s via sysfs" op dev; Ok Sysfs_successful
+        | Error _     when present_numvfs > 0 -> Ok(man_successful ())
+        | exception _ when present_numvfs > 0 -> Ok(man_successful ())
+        | Error err -> Error err
+        | exception e ->
+          let msg = Printf.sprintf "Error: trying sysfs SR-IOV interface failed with exception %s on device: %s" (Printexc.to_string e) dev in
+          Error(Other, msg)
       end
-      else Sysfs.set_sriov_numvfs dev numvfs) >>= fun _ ->
-      Ok Sysfs_successful
+      else
+      begin
+        Sysfs.unbind_child_vfs dev >>= fun () ->
+        Sysfs.set_sriov_numvfs dev 0 >>= fun _ ->
+        debug "%s SR-IOV on a device: %s via sysfs" op dev; Ok Sysfs_successful
+      end
 
   let enable dbg name =
     Debug.with_thread_associated dbg (fun () ->

--- a/networkd/network_server.ml
+++ b/networkd/network_server.ml
@@ -135,7 +135,13 @@ module Sriov = struct
         if enable then Sysfs.get_sriov_maxvfs dev
         else Sysfs.unbind_child_vfs dev >>= fun () -> Ok 0
       end >>= fun numvfs ->
-      Sysfs.set_sriov_numvfs dev numvfs >>= fun _ ->
+      let sysfs_numvfs = Sysfs.get_sriov_numvfs dev in
+      (if sysfs_numvfs <> 0 then
+      begin
+        debug "%d vfs already enabled on device: %s" sysfs_numvfs dev;
+        Ok ()
+      end
+      else Sysfs.set_sriov_numvfs dev numvfs) >>= fun _ ->
       Ok Sysfs_successful
 
   let enable dbg name =


### PR DESCRIPTION
When creating and enabling SR-IOV networks, using xapi, xcp-networkd tries to enable virtual functions on the physical adapter using sysfs interface. xcp-networkd tries to set the number of VFs equal to the maximum number of of virtual functions (`sriov_totalvfs`). When using adapters that do not fully implement the sysfs interface for SR-IOV configuration, currently, enabling fails. Enabling virtual functions via sysfs is executed even if the virtual functions are already enabled. Failing to execute the enabling procedure (even though unnecessary, when VFs are already enabled), prevents successful creation of an SR-IOV network.

*An example* are Mellanox ConnectX-3 cards, using `mlx4_core` driver: Virtual functions can be configured in firmware or using modprobe config. All configured virtual interfaces are enabled by default. The driver, though, does not allow configuration using the sysfs interface, and trying to write to `sriov_numvfs` fails; thus preventing successful creation and enabling of a SR-IOV network - even though, the virtual functions are enabled.

This pull request allows to use network adapters that require manual enabling (do not fully support configuration via sysfs interface)  with xapi/xcp-networkd managed SR-IOV networks, by checking for enabled VFs on the interface, prior to trying to enable them. When virtual functions are already enabled on the interface, enabling is skipped, a debug message about already enabled virtual functions is logged and `config_sriov` returns with `Ok Sysfs_successful` (`Ok Sysfs_successful` being the only valid return value for successfully enabling virtual functions).