### PR TITLE
Make dhclient send our hostname to the DHCP server

### DIFF
--- a/lib/network_utils.ml
+++ b/lib/network_utils.ml
@@ -760,7 +760,8 @@ struct
       else (debug "%s is NOT the DNS interface" interface; [])
     in
     let request = minimal @ set_gateway @ set_dns in
-    Printf.sprintf "interface \"%s\" {\n  send %s;\n  request %s;\n}\n" interface send (String.concat ", " request)
+    Printf.sprintf "interface \"%s\" {\n  send %s;\n  request %s;\n}\n"
+      interface send (String.concat ", " request)
 
   let read_conf_file ?(ipv6=false) interface =
     let file = conf_file ~ipv6 interface in

--- a/lib/network_utils.ml
+++ b/lib/network_utils.ml
@@ -746,6 +746,7 @@ struct
     Filename.concat "/var/lib/xcp" (Printf.sprintf "dhclient%s-%s.conf" ipv6' interface)
 
   let[@warning "-27"] generate_conf ?(ipv6=false) interface options =
+    let send = "host-name = gethostname()" in
     let minimal = ["subnet-mask"; "broadcast-address"; "time-offset"; "host-name"; "nis-domain";
                    "nis-servers"; "ntp-servers"; "interface-mtu"] in
     let set_gateway =
@@ -759,7 +760,7 @@ struct
       else (debug "%s is NOT the DNS interface" interface; [])
     in
     let request = minimal @ set_gateway @ set_dns in
-    Printf.sprintf "interface \"%s\" {\n  request %s;\n}\n" interface (String.concat ", " request)
+    Printf.sprintf "interface \"%s\" {\n  send %s;\n  request %s;\n}\n" interface send (String.concat ", " request)
 
   let read_conf_file ?(ipv6=false) interface =
     let file = conf_file ~ipv6 interface in

--- a/test/network_test_lacp_properties.ml
+++ b/test/network_test_lacp_properties.ml
@@ -51,6 +51,7 @@ module OVS_Cli_test = struct
   include Ovs.Cli
   let vsctl_output = ref []
   let vsctl ?log args =
+    (* Ignore unused argument to avoid warning under dune's default settings. *)
     ignore log;
     vsctl_output := args ;
     String.concat " " args

--- a/test/network_test_lacp_properties.ml
+++ b/test/network_test_lacp_properties.ml
@@ -50,9 +50,7 @@ let test_lacp_aggregation_key arg () =
 module OVS_Cli_test = struct
   include Ovs.Cli
   let vsctl_output = ref []
-  let vsctl ?log args =
-    (* Ignore unused argument to avoid warning under dune's default settings. *)
-    ignore log;
+  let vsctl ?log:_ args =
     vsctl_output := args ;
     String.concat " " args
 end

--- a/test/network_test_lacp_properties.ml
+++ b/test/network_test_lacp_properties.ml
@@ -51,7 +51,7 @@ module OVS_Cli_test = struct
   include Ovs.Cli
   let vsctl_output = ref []
   let vsctl ?log args =
-    ignore(log);
+    ignore log;
     vsctl_output := args ;
     String.concat " " args
 end

--- a/test/network_test_lacp_properties.ml
+++ b/test/network_test_lacp_properties.ml
@@ -51,6 +51,7 @@ module OVS_Cli_test = struct
   include Ovs.Cli
   let vsctl_output = ref []
   let vsctl ?log args =
+    ignore(log);
     vsctl_output := args ;
     String.concat " " args
 end


### PR DESCRIPTION
This generates a config file of the form:

```
interface "xenbr0" {
  send host-name = gethostname();
  request subnet-mask, broadcast-address, time-offset, host-name, nis-domain, nis-servers, ntp-servers, interface-mtu, routers, domain-name, domain-name-servers;
}
```
