### PR TITLE
CA-347400: Pass lease file when stopping dhclient

### DIFF
--- a/lib/network_utils.ml
+++ b/lib/network_utils.ml
@@ -976,7 +976,14 @@ end = struct
     try
       ignore
         (call_script dhclient
-           ["-r"; "-pf"; pid_file ~ipv6 interface; interface]) ;
+           [
+             "-r"
+           ; "-pf"
+           ; pid_file ~ipv6 interface
+           ; "-lf"
+           ; lease_file ~ipv6 interface
+           ; interface
+           ]) ;
       Unix.unlink (pid_file ~ipv6 interface)
     with _ -> ()
 


### PR DESCRIPTION
xcp-networkd calls "dhclient -r" which releases the
current lease and stops the existing dhclient process. For some reason,
dhclient skips calling dhclient-script unless the lease file is given on
the command-line. This means that the dhclient hooks are not run which
in turn means that NTP servers obtained from DHCP are not removed.

Fix this by simply passing the lease file when stopping dhclient.

Signed-off-by: Ross Lagerwall <ross.lagerwall@citrix.com>