### PR TITLE
CA-351826 recognise link/infiniband MAC address

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,5 +1,4 @@
 profile=ocamlformat
-version=0.14.1
 indicate-multiline-delimiters=closing-on-separate-line
 if-then-else=fit-or-vertical
 dock-collection-brackets=true

--- a/lib/network_utils.ml
+++ b/lib/network_utils.ml
@@ -491,8 +491,11 @@ module Ip = struct
       | m :: _ ->
           m
       | [] ->
-          error "can't find mac address for %s" dev ;
-          ""
+          let msg =
+            Printf.sprintf "can't find mac address for %s (%s)" dev __LOC__
+          in
+          error "%s" msg ;
+          raise (Network_error (Internal_error msg))
     )
     | m :: _ ->
         m

--- a/lib/network_utils.ml
+++ b/lib/network_utils.ml
@@ -141,15 +141,6 @@ let fork_script ?on_error ?log script args =
   check_n_run ?on_error ?log fork_script_internal script args
 
 module Sysfs = struct
-  let list () =
-    let all = Array.to_list (Sys.readdir "/sys/class/net") in
-    List.filter (fun name -> Sys.is_directory ("/sys/class/net/" ^ name)) all
-
-  let exists dev = List.mem dev @@ list ()
-
-  let assert_exists dev =
-    if not @@ exists dev then
-      raise (Network_error (Interface_does_not_exist dev))
 
   let list_drivers () =
     try Array.to_list (Sys.readdir "/sys/bus/pci/drivers")
@@ -194,6 +185,29 @@ module Sysfs = struct
         (List.mem "xen-backend"
            (Astring.String.cuts ~empty:false ~sep:"/" driver_link))
     with _ -> false
+
+  (* device types are defined in linux/if_arp.h *)
+  let is_ether_device name =
+    match int_of_string (read_one_line (getpath name "type")) with
+    | 1 ->
+        true
+    | _ ->
+        false
+    | exception _ ->
+        false
+
+  let list () =
+    let is_dir name = Sys.is_directory ("/sys/class/net/" ^ name) in
+    Sys.readdir "/sys/class/net"
+    |> Array.to_list
+    |> List.filter (fun name -> is_dir name && is_ether_device name)
+
+  let exists dev = List.mem dev @@ list ()
+
+  let assert_exists dev =
+    if not @@ exists dev then
+      raise (Network_error (Interface_does_not_exist dev))
+
 
   let get_carrier name =
     try

--- a/lib/network_utils.ml
+++ b/lib/network_utils.ml
@@ -484,7 +484,18 @@ module Ip = struct
 
   let get_mtu dev = int_of_string (List.hd (link dev "mtu"))
 
-  let get_mac dev = List.hd (link dev "link/ether")
+  let get_mac dev =
+    match link dev "link/ether" with
+    | [] -> (
+      match link dev "link/infiniband" with
+      | m :: _ ->
+          m
+      | [] ->
+          error "can't find mac address for %s" dev ;
+          ""
+    )
+    | m :: _ ->
+        m
 
   let set_mac dev mac =
     try ignore (link_set dev ["address"; mac]) with _ -> ()

--- a/networkd/network_server.ml
+++ b/networkd/network_server.ml
@@ -672,10 +672,10 @@ module Interface = struct
                        derive the intention of the caller by looking at other
                        fields. *)
                     match (ipv4_conf, ipv6_conf) with
-                    | (Static4 _, _)
-                    | (_, Static6 _)
-                    | (_, Autoconf6) -> set_dns () dbg ~name ~nameservers ~domains
-                    | _ -> ());
+                    | Static4 _, _ | _, Static6 _ | _, Autoconf6 ->
+                        set_dns () dbg ~name ~nameservers ~domains
+                    | _ ->
+                        ()) ;
                 exec (fun () -> set_ipv4_conf dbg name ipv4_conf) ;
                 exec (fun () ->
                     match ipv4_gateway with


### PR DESCRIPTION
xcp-networkd fails to recognise the MAC address of an infiniband NIC
because it only looks for link/ether and misses link/infiniband. If the
former fails, look for link/infiniband, too.

This code could be made more general by using regular expressions for
search rather than strings. However, this would create more changes
which could complicate backports.

This is in response to https://github.com/xapi-project/xcp-networkd/issues/184


Signed-off-by: Christian Lindig <christian.lindig@citrix.com>