### PR TITLE
CA-351826 stockholm backport - ignore non-ethernet PIFs

### DIFF
--- a/lib/network_utils.ml
+++ b/lib/network_utils.ml
@@ -491,8 +491,11 @@ module Ip = struct
       | m :: _ ->
           m
       | [] ->
-          error "can't find mac address for %s" dev ;
-          ""
+          let msg =
+            Printf.sprintf "can't find mac address for %s (%s)" dev __LOC__
+          in
+          error "%s" msg ;
+          raise (Network_error (Internal_error msg))
     )
     | m :: _ ->
         m

--- a/lib/network_utils.ml
+++ b/lib/network_utils.ml
@@ -141,15 +141,6 @@ let fork_script ?on_error ?log script args =
   check_n_run ?on_error ?log fork_script_internal script args
 
 module Sysfs = struct
-  let list () =
-    let all = Array.to_list (Sys.readdir "/sys/class/net") in
-    List.filter (fun name -> Sys.is_directory ("/sys/class/net/" ^ name)) all
-
-  let exists dev = List.mem dev @@ list ()
-
-  let assert_exists dev =
-    if not @@ exists dev then
-      raise (Network_error (Interface_does_not_exist dev))
 
   let list_drivers () =
     try Array.to_list (Sys.readdir "/sys/bus/pci/drivers")
@@ -194,6 +185,29 @@ module Sysfs = struct
         (List.mem "xen-backend"
            (Astring.String.cuts ~empty:false ~sep:"/" driver_link))
     with _ -> false
+
+  (* device types are defined in linux/if_arp.h *)
+  let is_ether_device name =
+    match int_of_string (read_one_line (getpath name "type")) with
+    | 1 ->
+        true
+    | _ ->
+        false
+    | exception _ ->
+        false
+
+  let list () =
+    let is_dir name = Sys.is_directory ("/sys/class/net/" ^ name) in
+    Sys.readdir "/sys/class/net"
+    |> Array.to_list
+    |> List.filter (fun name -> is_dir name && is_ether_device name)
+
+  let exists dev = List.mem dev @@ list ()
+
+  let assert_exists dev =
+    if not @@ exists dev then
+      raise (Network_error (Interface_does_not_exist dev))
+
 
   let get_carrier name =
     try

--- a/lib/network_utils.ml
+++ b/lib/network_utils.ml
@@ -484,7 +484,18 @@ module Ip = struct
 
   let get_mtu dev = int_of_string (List.hd (link dev "mtu"))
 
-  let get_mac dev = List.hd (link dev "link/ether")
+  let get_mac dev =
+    match link dev "link/ether" with
+    | [] -> (
+      match link dev "link/infiniband" with
+      | m :: _ ->
+          m
+      | [] ->
+          error "can't find mac address for %s" dev ;
+          ""
+    )
+    | m :: _ ->
+        m
 
   let set_mac dev mac =
     try ignore (link_set dev ["address"; mac]) with _ -> ()


### PR DESCRIPTION
The CA was triggered by a user with Infiniband devices that show up as network devices but are not supported. The original failure was that no mac address was found under `link/ether`. We now skip over devices that are not ethernet devices in the `list()` function that enumerates network interfaces. Backport of:

* 6db73c02 CA-351826 ensure PIF is an ethernet device                       
* 9ddfbf96 CA-351826 fail if we can't find MAC address of interface         
* 8678423d CA-351826 recognise link/infiniband MAC address       
