### PR TITLE
maintenance: explicitly import xapi_stdext_std

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,9 +3,6 @@ name: Build and test
 on:
   push:
   pull_request:
-  schedule:
-    # run daily, this refreshes the cache
-    - cron: '30 4 * * *'
 
 jobs:
   ocaml-test:
@@ -24,20 +21,7 @@ jobs:
 
       - name: Load environment file
         id: dotenv
-        uses: falti/dotenv-action@v0.2.4
-
-      - name: Retrieve date for cache key
-        id: cache-key
-        run: echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
-        shell: bash
-
-      - name: Restore opam cache
-        id: opam-cache
-        uses: actions/cache@v2
-        with:
-          path: "~/.opam"
-          # invalidate cache daily, gets built daily using a scheduled job
-          key: ${{ steps.cache-key.outputs.date }}
+        uses: falti/dotenv-action@v0.2.5
 
       - name: Use ocaml
         uses: avsm/setup-ocaml@v1
@@ -63,8 +47,3 @@ jobs:
 
       - name: Run tests
         run: opam exec -- make test
-
-      - name: Uninstall unversioned packages
-        # This should purge them from the cache, unversioned package have
-        # 'master' as its version
-        run: opam list | awk -F " " '$2 == "master" { print $1 }' |  xargs opam uninstall

--- a/lib/dune
+++ b/lib/dune
@@ -9,6 +9,7 @@
   systemd
   threads
   re.perl
+  xapi-stdext-std
   xapi-stdext-unix
   xapi-inventory
   xapi-idl.network)

--- a/xapi-networkd.opam
+++ b/xapi-networkd.opam
@@ -21,6 +21,7 @@ depends: [
   "xapi-idl"
   "xapi-inventory"
   "xapi-stdext-pervasives"
+  "xapi-stdext-std"
   "xapi-stdext-threads"
   "xapi-stdext-unix"
   "xapi-test-utils"


### PR DESCRIPTION
It's being imported transitively using xapi_stdext_unix, but this will
break when unixexts drops that dependency as it isn't using it.

Signed-off-by: Pau Ruiz Safont <pau.safont@citrix.com>