### PR TITLE
CA-359978 UPD-825: Flush IP addresses when switching from static to DHCP

### DIFF
--- a/networkd/network_server.ml
+++ b/networkd/network_server.ml
@@ -280,6 +280,8 @@ module Interface = struct
             let dns =
               Opt.default [] (Opt.map (fun n -> [`dns n]) !config.dns_interface)
             in
+            if not (Dhclient.is_running name) then (* Remove any static IPs *)
+              Ip.flush_ip_addr name ;
             let options = gateway @ dns in
             Dhclient.ensure_running name options
         | Static4 addrs ->


### PR DESCRIPTION
Backport of be440f369e91fccfc4f94b9ba7ac03f382626067 from xen-api.git

Switching to DHCP does not simply replace existing IP addresses, but
may add one in addition.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>
Signed-off-by: Christian Lindig <christian.lindig@citrix.com>